### PR TITLE
init chrono class

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": ["biomejs.biome", "vitest.explorer"],
+
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": ["prettier.prettier-vscode"]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,10 @@
 {
-  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+  /* See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations. */
+  /* Extension identifier format: ${publisher}.${name}. Example: vscode.csharp */
 
-  // List of extensions which should be recommended for users of this workspace.
+  /* List of extensions which should be recommended for users of this workspace. */
   "recommendations": ["biomejs.biome", "vitest.explorer"],
 
-  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  /* List of extensions recommended by VS Code that should not be recommended for users of this workspace. */
   "unwantedRecommendations": ["prettier.prettier-vscode"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,10 +1,4 @@
 {
-  /* See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations. */
-  /* Extension identifier format: ${publisher}.${name}. Example: vscode.csharp */
-
-  /* List of extensions which should be recommended for users of this workspace. */
   "recommendations": ["biomejs.biome", "vitest.explorer"],
-
-  /* List of extensions recommended by VS Code that should not be recommended for users of this workspace. */
   "unwantedRecommendations": ["prettier.prettier-vscode"]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "packageManager": "pnpm@10.6.2",
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@faker-js/faker": "^9.6.0",
     "@types/node": "20.17.24",
     "husky": "^9.1.7",
     "rimraf": "^6.0.1",

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -41,15 +41,21 @@ export class Chrono<TaskKind, DatastoreOptions> extends EventEmitter {
   public async scheduleTask<TaskData>(
     input: ScheduleTaskInput<TaskKind, TaskData, DatastoreOptions>,
   ): Promise<Task<TaskKind, TaskData>> {
-    const task = await this.#datastore.schedule({
-      when: input.when,
-      kind: input.kind,
-      data: input.data,
-      datastoreOptions: input.datastoreOptions,
-    });
+    try {
+      const task = await this.#datastore.schedule({
+        when: input.when,
+        kind: input.kind,
+        data: input.data,
+        datastoreOptions: input.datastoreOptions,
+      });
 
-    this.emit('task-scheduled', { task, timestamp: new Date() });
+      this.emit('task-scheduled', { task, timestamp: new Date() });
 
-    return task;
+      return task;
+    } catch (error) {
+      this.emit('task-schedule-failed', { error, input, timestamp: new Date() });
+
+      throw error;
+    }
   }
 }

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -13,11 +13,19 @@ export class Chrono<TaskKind, DatastoreOptions> extends EventEmitter {
     this.#datastore = datastore;
   }
 
-  public async initialize(): Promise<void> {
+  public async start(): Promise<void> {
     // Emit ready event when the instance is ready.
     // This is useful for consumers to know when the instance is ready to accept tasks.
     // In the future, we might want to add more initialization logic here, like ensuring the datastore is connected.
     this.emit('ready', { timestamp: new Date() });
+  }
+
+  public async stop(): Promise<void> {
+    // Emit close event when the instance is closed.
+    // This is useful for consumers to know when the instance is closed and no longer accepting tasks.
+    // In the future, we might want to add more cleanup logic here, like closing the datastore connection
+    // and stopping all handlers.
+    this.emit('close', { timestamp: new Date() });
   }
 
   public async scheduleTask<TaskData>(

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -34,8 +34,13 @@ export class Chrono<TaskKind, DatastoreOptions> extends EventEmitter {
     super();
 
     this.#datastore = datastore;
+  }
 
-    this.emit('instantiated', { timestamp: new Date() });
+  public async initialize(): Promise<void> {
+    // Emit ready event when the instance is ready.
+    // This is useful for consumers to know when the instance is ready to accept tasks.
+    // In the future, we might want to add more initialization logic here, like ensuring the datastore is connected.
+    this.emit('ready', { timestamp: new Date() });
   }
 
   public async scheduleTask<TaskData>(

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -1,0 +1,55 @@
+import { EventEmitter } from 'node:stream';
+
+export type TaskStatus = 'pending' | 'claimed' | 'completed' | 'failed';
+
+export type Task<TaskKind, TaskData> = {
+  id: string;
+  kind: TaskKind;
+  status: TaskStatus;
+  data: TaskData;
+  scheduledAt: Date;
+};
+
+type ScheduleInput<TaskKind, TaskData, DatastoreOptions> = {
+  when: Date;
+  kind: TaskKind;
+  data: TaskData;
+  priority?: 0;
+  idempotencyKey?: string;
+  datastoreOptions?: DatastoreOptions;
+};
+
+export interface Datastore<DatastoreOptions> {
+  schedule<TaskKind, TaskData>(
+    input: ScheduleInput<TaskKind, TaskData, DatastoreOptions>,
+  ): Promise<Task<TaskKind, TaskData>>;
+}
+
+type ScheduleTaskInput<TaskKind, TaskData, DatastoreOptions> = ScheduleInput<TaskKind, TaskData, DatastoreOptions>;
+
+export class Chrono<TaskKind, DatastoreOptions> extends EventEmitter {
+  #datastore: Datastore<DatastoreOptions>;
+
+  constructor(datastore: Datastore<DatastoreOptions>) {
+    super();
+
+    this.#datastore = datastore;
+
+    this.emit('instantiated', { timestamp: new Date() });
+  }
+
+  public async scheduleTask<TaskData>(
+    input: ScheduleTaskInput<TaskKind, TaskData, DatastoreOptions>,
+  ): Promise<Task<TaskKind, TaskData>> {
+    const task = await this.#datastore.schedule({
+      when: input.when,
+      kind: input.kind,
+      data: input.data,
+      datastoreOptions: input.datastoreOptions,
+    });
+
+    this.emit('task-scheduled', { task, timestamp: new Date() });
+
+    return task;
+  }
+}

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -1,29 +1,6 @@
 import { EventEmitter } from 'node:stream';
 
-export type TaskStatus = 'pending' | 'claimed' | 'completed' | 'failed';
-
-export type Task<TaskKind, TaskData> = {
-  id: string;
-  kind: TaskKind;
-  status: TaskStatus;
-  data: TaskData;
-  scheduledAt: Date;
-};
-
-type ScheduleInput<TaskKind, TaskData, DatastoreOptions> = {
-  when: Date;
-  kind: TaskKind;
-  data: TaskData;
-  priority?: 0;
-  idempotencyKey?: string;
-  datastoreOptions?: DatastoreOptions;
-};
-
-export interface Datastore<DatastoreOptions> {
-  schedule<TaskKind, TaskData>(
-    input: ScheduleInput<TaskKind, TaskData, DatastoreOptions>,
-  ): Promise<Task<TaskKind, TaskData>>;
-}
+import type { Datastore, ScheduleInput, Task } from './datastore';
 
 type ScheduleTaskInput<TaskKind, TaskData, DatastoreOptions> = ScheduleInput<TaskKind, TaskData, DatastoreOptions>;
 

--- a/packages/chrono-core/src/datastore.ts
+++ b/packages/chrono-core/src/datastore.ts
@@ -1,10 +1,15 @@
 export type TaskStatus = 'pending' | 'claimed' | 'completed' | 'failed';
 
 export type Task<TaskKind, TaskData> = {
+  /** A unique identifier for the task */
   id: string;
+  /** A human-readable name or type for the task */
   kind: TaskKind;
+  /** The current status of the task */
   status: TaskStatus;
+  /** The payload or data associated with the task */
   data: TaskData;
+  /** The current scheduled execution date, which may change if rescheduled */
   scheduledAt: Date;
 };
 

--- a/packages/chrono-core/src/datastore.ts
+++ b/packages/chrono-core/src/datastore.ts
@@ -1,0 +1,24 @@
+export type TaskStatus = 'pending' | 'claimed' | 'completed' | 'failed';
+
+export type Task<TaskKind, TaskData> = {
+  id: string;
+  kind: TaskKind;
+  status: TaskStatus;
+  data: TaskData;
+  scheduledAt: Date;
+};
+
+export type ScheduleInput<TaskKind, TaskData, DatastoreOptions> = {
+  when: Date;
+  kind: TaskKind;
+  data: TaskData;
+  priority?: 0;
+  idempotencyKey?: string;
+  datastoreOptions?: DatastoreOptions;
+};
+
+export interface Datastore<DatastoreOptions> {
+  schedule<TaskKind, TaskData>(
+    input: ScheduleInput<TaskKind, TaskData, DatastoreOptions>,
+  ): Promise<Task<TaskKind, TaskData>>;
+}

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -14,14 +14,25 @@ describe('Chrono', () => {
 
   const chrono = new Chrono<TaskKind, DatastoreOptions>(mockDatastore);
 
-  describe('initialize', () => {
+  describe('start', () => {
     test('emits ready event when chrono is instantiated successfully', async () => {
       const emitSpy = vitest.spyOn(chrono, 'emit');
 
-      await chrono.initialize();
+      await chrono.start();
 
       expect(emitSpy).toHaveBeenCalledOnce();
       expect(emitSpy).toHaveBeenCalledWith('ready', { timestamp: expect.any(Date) });
+    });
+  });
+
+  describe('stop', () => {
+    test('emits close event when chrono is stopped successfully', async () => {
+      const emitSpy = vitest.spyOn(chrono, 'emit');
+
+      await chrono.stop();
+
+      expect(emitSpy).toHaveBeenCalledOnce();
+      expect(emitSpy).toHaveBeenCalledWith('close', { timestamp: expect.any(Date) });
     });
   });
 

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -69,5 +69,28 @@ describe('Chrono', () => {
         timestamp: expect.any(Date),
       });
     });
+
+    test('emits task-schedule-fail event when datastore fails', async () => {
+      const mockDatastoreError = new Error('Failed to schedule task');
+
+      mockDatastore.schedule.mockRejectedValueOnce(mockDatastoreError);
+
+      const emitSpy = vitest.spyOn(chrono, 'emit');
+
+      const mockScheduleTaskInput = {
+        when: mockScheduleInput.scheduledAt,
+        kind: mockScheduleInput.kind,
+        data: mockScheduleInput.data,
+      };
+
+      await expect(chrono.scheduleTask(mockScheduleTaskInput)).rejects.toThrow('Failed to schedule task');
+
+      expect(emitSpy).toHaveBeenCalledOnce();
+      expect(emitSpy).toHaveBeenCalledWith('task-schedule-failed', {
+        error: mockDatastoreError,
+        input: mockScheduleTaskInput,
+        timestamp: expect.any(Date),
+      });
+    });
   });
 });

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -2,8 +2,8 @@ import { faker } from '@faker-js/faker';
 import { describe, expect, test, vitest } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
-import type { Datastore, Task } from '../../src/chrono';
 import { Chrono } from '../../src/chrono';
+import type { Datastore, Task } from '../../src/datastore';
 
 describe('Chrono', () => {
   type TaskKind = 'send-test-task';

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -1,0 +1,64 @@
+import { faker } from '@faker-js/faker';
+import { describe, expect, test, vitest } from 'vitest';
+import { mock } from 'vitest-mock-extended';
+
+import type { Datastore, Task } from '../../src/chrono';
+import { Chrono } from '../../src/chrono';
+
+describe('Chrono', () => {
+  type TaskKind = 'send-test-task';
+  type TaskData = { someField: number };
+  type DatastoreOptions = Record<string, unknown>;
+
+  const mockDatastore = mock<Datastore<DatastoreOptions>>();
+
+  const chrono = new Chrono<TaskKind, DatastoreOptions>(mockDatastore);
+
+  describe('scheduleTask', () => {
+    test('schedule a task successfully', async () => {
+      const mockScheduleInput: Task<TaskKind, TaskData> = {
+        id: faker.string.nanoid(),
+        kind: 'send-test-task',
+        status: 'pending',
+        data: { someField: 1 },
+        scheduledAt: faker.date.future(),
+      };
+
+      mockDatastore.schedule.mockResolvedValueOnce(mockScheduleInput);
+
+      const result = await chrono.scheduleTask({
+        when: mockScheduleInput.scheduledAt,
+        kind: mockScheduleInput.kind,
+        data: mockScheduleInput.data,
+      });
+
+      expect(result).toEqual(mockScheduleInput);
+    });
+
+    test('emits task-scheduled event successfully', async () => {
+      const mockScheduleInput: Task<TaskKind, TaskData> = {
+        id: faker.string.nanoid(),
+        kind: 'send-test-task',
+        status: 'pending',
+        data: { someField: 1 },
+        scheduledAt: faker.date.future(),
+      };
+
+      mockDatastore.schedule.mockResolvedValueOnce(mockScheduleInput);
+
+      const emitSpy = vitest.spyOn(chrono, 'emit');
+
+      await chrono.scheduleTask({
+        when: mockScheduleInput.scheduledAt,
+        kind: mockScheduleInput.kind,
+        data: mockScheduleInput.data,
+      });
+
+      expect(emitSpy).toHaveBeenCalledOnce();
+      expect(emitSpy).toHaveBeenCalledWith('task-scheduled', {
+        task: mockScheduleInput,
+        timestamp: expect.any(Date),
+      });
+    });
+  });
+});

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -14,6 +14,17 @@ describe('Chrono', () => {
 
   const chrono = new Chrono<TaskKind, DatastoreOptions>(mockDatastore);
 
+  describe('initialize', () => {
+    test('emits ready event when chrono is instantiated successfully', async () => {
+      const emitSpy = vitest.spyOn(chrono, 'emit');
+
+      await chrono.initialize();
+
+      expect(emitSpy).toHaveBeenCalledOnce();
+      expect(emitSpy).toHaveBeenCalledWith('ready', { timestamp: expect.any(Date) });
+    });
+  });
+
   describe('scheduleTask', () => {
     const mockScheduleInput: Task<TaskKind, TaskData> = {
       id: faker.string.nanoid(),

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -15,15 +15,15 @@ describe('Chrono', () => {
   const chrono = new Chrono<TaskKind, DatastoreOptions>(mockDatastore);
 
   describe('scheduleTask', () => {
-    test('schedule a task successfully', async () => {
-      const mockScheduleInput: Task<TaskKind, TaskData> = {
-        id: faker.string.nanoid(),
-        kind: 'send-test-task',
-        status: 'pending',
-        data: { someField: 1 },
-        scheduledAt: faker.date.future(),
-      };
+    const mockScheduleInput: Task<TaskKind, TaskData> = {
+      id: faker.string.nanoid(),
+      kind: 'send-test-task',
+      status: 'pending',
+      data: { someField: 1 },
+      scheduledAt: faker.date.future(),
+    };
 
+    test('schedule a task successfully', async () => {
       mockDatastore.schedule.mockResolvedValueOnce(mockScheduleInput);
 
       const result = await chrono.scheduleTask({
@@ -35,15 +35,24 @@ describe('Chrono', () => {
       expect(result).toEqual(mockScheduleInput);
     });
 
-    test('emits task-scheduled event successfully', async () => {
-      const mockScheduleInput: Task<TaskKind, TaskData> = {
-        id: faker.string.nanoid(),
-        kind: 'send-test-task',
-        status: 'pending',
-        data: { someField: 1 },
-        scheduledAt: faker.date.future(),
-      };
+    test('calls datastore.schedule successfully', async () => {
+      mockDatastore.schedule.mockResolvedValueOnce(mockScheduleInput);
 
+      await chrono.scheduleTask({
+        when: mockScheduleInput.scheduledAt,
+        kind: mockScheduleInput.kind,
+        data: mockScheduleInput.data,
+      });
+
+      expect(mockDatastore.schedule).toHaveBeenCalledOnce();
+      expect(mockDatastore.schedule).toHaveBeenCalledWith({
+        when: mockScheduleInput.scheduledAt,
+        kind: mockScheduleInput.kind,
+        data: mockScheduleInput.data,
+      });
+    });
+
+    test('emits task-scheduled event successfully', async () => {
       mockDatastore.schedule.mockResolvedValueOnce(mockScheduleInput);
 
       const emitSpy = vitest.spyOn(chrono, 'emit');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@faker-js/faker':
+        specifier: ^9.6.0
+        version: 9.6.0
       '@types/node':
         specifier: 20.17.24
         version: 20.17.24
@@ -242,6 +245,10 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@faker-js/faker@9.6.0':
+    resolution: {integrity: sha512-3vm4by+B5lvsFPSyep3ELWmZfE3kicDtmemVpuwl1yH7tqtnHdsA6hG8fbXedMVdkzgtvzWoRgjSB4Q+FHnZiw==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -840,6 +847,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.1':
     optional: true
+
+  '@faker-js/faker@9.6.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:


### PR DESCRIPTION
### Description

Initial `Chrono` class with the following methods:
- `start` - emits `ready` event for now.
- `stop` - emits `close` event for now.
- `scheduleTask` - calls `#datastore` to do the task persistence and emits `tasks-scheduled` event.