### PR TITLE
Implement chrono start and stop

### DIFF
--- a/examples/sample-memory-datastore-app/src/main.ts
+++ b/examples/sample-memory-datastore-app/src/main.ts
@@ -12,10 +12,6 @@ async function main() {
   const memoryDatastore = new ChronoMemoryDatastore<TaskMapping, DatastoreOptions>();
   const chrono = new Chrono<TaskMapping, DatastoreOptions>(memoryDatastore);
 
-  const data = {
-    someField: 123,
-  };
-
   chrono.registerTaskHandler({
     kind: 'async-messaging',
     handler: async (task) => {
@@ -30,10 +26,12 @@ async function main() {
     },
   });
 
+  await chrono.start();
+
   const result = await chrono.scheduleTask({
     when: new Date(),
     kind: 'async-messaging',
-    data,
+    data: { someField: 123 },
   });
 
   console.log('scheduled task:', result);
@@ -41,12 +39,12 @@ async function main() {
   const result2 = await chrono.scheduleTask({
     when: new Date(),
     kind: 'send-email',
-    data: {
-      url: 'https://example.com',
-    },
+    data: { url: 'https://example.com' },
   });
 
   console.log('scheduled task:', result2);
+
+  await chrono.stop();
 }
 
 main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "keywords": [],
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
-  "packageManager": "pnpm@10.6.2",
+  "packageManager": "pnpm@10.6.5",
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@faker-js/faker": "^9.6.0",

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -15,12 +15,17 @@ export type RegisterTaskHandlerInput<TaskKind, TaskData> = {
   handler: (task: Task<TaskKind, TaskData>) => Promise<void>;
 };
 
-/*
-type TaskMapping = {
-  "async-messaging": { someField: number };
-  "send-email": { url: string };
-};
-*/
+/**
+ * This is a type that represents the mapping of task kinds to their respective data types.
+ *
+ * Eg. shape of the TaskMapping type:
+ *
+ * type TaskMapping = {
+ *   "async-messaging": { someField: number };
+ *   "send-email": { url: string };
+ * };
+ *
+ */
 
 export class Chrono<TaskMapping extends TaskMappingBase, DatastoreOptions> extends EventEmitter {
   private datastore: Datastore<
@@ -37,17 +42,18 @@ export class Chrono<TaskMapping extends TaskMappingBase, DatastoreOptions> exten
   }
 
   public async start(): Promise<void> {
-    // Emit ready event when the instance is ready.
-    // This is useful for consumers to know when the instance is ready to accept tasks.
-    // In the future, we might want to add more initialization logic here, like ensuring the datastore is connected.
+    for (const processor of this.processors.values()) {
+      await processor.start();
+    }
+
     this.emit('ready', { timestamp: new Date() });
   }
 
   public async stop(): Promise<void> {
-    // Emit close event when the instance is closed.
-    // This is useful for consumers to know when the instance is closed and no longer accepting tasks.
-    // In the future, we might want to add more cleanup logic here, like closing the datastore connection
-    // and stopping all handlers.
+    for (const processor of this.processors.values()) {
+      await processor.stop();
+    }
+
     this.emit('close', { timestamp: new Date() });
   }
 

--- a/packages/chrono-core/src/processors/create-processor.ts
+++ b/packages/chrono-core/src/processors/create-processor.ts
@@ -1,0 +1,26 @@
+import type { Datastore, Task } from 'datastore';
+import type { Processor } from './processor';
+import { SimpleProcessor } from './simple-processor';
+
+export type ProcessorConfiguration = {
+  maxConcurrency: number;
+};
+
+export type CreateProcessorInput<TaskKind, TaskData, DatastoreOptions> = {
+  kind: TaskKind;
+  datastore: Datastore<TaskKind, TaskData, DatastoreOptions>;
+  handler: (task: Task<TaskKind, TaskData>) => Promise<void>;
+  configuration: ProcessorConfiguration;
+};
+
+export function createProcessor<TaskKind, TaskData, DatastoreOptions>(
+  input: CreateProcessorInput<TaskKind, TaskData, DatastoreOptions>,
+): Processor {
+  // add more processors here
+  return new SimpleProcessor<TaskKind, TaskData, DatastoreOptions>({
+    datastore: input.datastore,
+    kind: input.kind,
+    handler: input.handler,
+    maxConcurrency: input.configuration.maxConcurrency,
+  });
+}

--- a/packages/chrono-core/src/processors/index.ts
+++ b/packages/chrono-core/src/processors/index.ts
@@ -1,25 +1,2 @@
-import type { Datastore, Task } from '../datastore';
-import { SimpleProcessor } from './simple-processor';
-
-export interface Processor {
-  start(): void;
-  stop(): Promise<void>;
-}
-
-export type ProcessorConfiguration = {
-  maxConcurrency: number;
-};
-
-export type CreateProcessorInput<TaskKind, TaskData, DatastoreOptions> = {
-  kind: TaskKind;
-  datastore: Datastore<TaskKind, TaskData, DatastoreOptions>;
-  handler: (task: Task<TaskKind, TaskData>) => Promise<void>;
-  configuration: ProcessorConfiguration;
-};
-
-export function createProcessor<TaskKind, TaskData, DatastoreOptions>(
-  input: CreateProcessorInput<TaskKind, TaskData, DatastoreOptions>,
-): Processor {
-  // add more processors here
-  return new SimpleProcessor<TaskKind, TaskData, DatastoreOptions>(input);
-}
+export { createProcessor } from './create-processor';
+export type { Processor } from './processor';

--- a/packages/chrono-core/src/processors/processor.ts
+++ b/packages/chrono-core/src/processors/processor.ts
@@ -1,0 +1,48 @@
+import { EventEmitter } from 'node:stream';
+
+export interface Processor {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+export type TaskErrorEvent = {
+  taskIndex: number;
+  error: Error;
+  timestamp: Date;
+};
+
+/**
+ * Emits 'error' event when a task exits because of an error.
+ */
+export class TaskErrorChannel extends EventEmitter {
+  emitError(taskIndex: number, error: Error): void {
+    this.emit('error', { taskIndex, error, timestamp: new Date() } as TaskErrorEvent);
+  }
+
+  onError(handler: (errorEvent: TaskErrorEvent) => void): void {
+    this.on('error', (event: TaskErrorEvent) => handler(event));
+  }
+}
+
+/**
+ * This class is a wrapper to its task which emits an error event if the task fails.
+ */
+export class TaskRunner {
+  private taskIndex: number;
+  private task: () => Promise<void>;
+  private errorChannel: TaskErrorChannel;
+
+  constructor(taskIndex: number, errorChannel: TaskErrorChannel, task: () => Promise<void>) {
+    this.taskIndex = taskIndex;
+    this.task = task;
+    this.errorChannel = errorChannel;
+  }
+
+  async run(): Promise<void> {
+    try {
+      await this.task();
+    } catch (error) {
+      this.errorChannel.emitError(this.taskIndex, error as Error);
+    }
+  }
+}

--- a/packages/chrono-core/src/processors/simple-processor.ts
+++ b/packages/chrono-core/src/processors/simple-processor.ts
@@ -1,8 +1,15 @@
 import { EventEmitter } from 'node:stream';
 import { setTimeout } from 'node:timers/promises';
 
-import type { CreateProcessorInput, Processor } from '.';
 import type { Datastore, Task } from '../datastore';
+import { type Processor, TaskErrorChannel, TaskRunner } from './processor';
+
+type SimpleProcessorConfig<TaskKind, TaskData, DatastoreOptions> = {
+  datastore: Datastore<TaskKind, TaskData, DatastoreOptions>;
+  kind: TaskKind;
+  handler: (task: Task<TaskKind, TaskData>) => Promise<void>;
+  maxConcurrency: number;
+};
 
 export class SimpleProcessor<TaskKind, TaskData, DatastoreOptions> extends EventEmitter implements Processor {
   private taskKind: TaskKind;
@@ -12,47 +19,58 @@ export class SimpleProcessor<TaskKind, TaskData, DatastoreOptions> extends Event
   private stopRequested = false;
   private maxConcurrency: number;
 
-  constructor(input: CreateProcessorInput<TaskKind, TaskData, DatastoreOptions>) {
+  readonly claimIntervalMs = 150;
+  readonly idleIntervalMs = 5_000;
+
+  constructor(config: SimpleProcessorConfig<TaskKind, TaskData, DatastoreOptions>) {
     super();
 
-    this.datastore = input.datastore;
-    this.handler = input.handler;
-    this.maxConcurrency = input.configuration.maxConcurrency;
-    this.taskKind = input.kind;
+    this.datastore = config.datastore;
+    this.handler = config.handler;
+    this.maxConcurrency = config.maxConcurrency;
+    this.taskKind = config.kind;
   }
 
-  start(): void {
-    if (this.runningTasks.length >= 0) {
+  async start(): Promise<void> {
+    if (this.stopRequested || this.runningTasks.length >= 0) {
       return;
     }
 
-    this.stopRequested = false;
-
     for (let i = 0; i < this.maxConcurrency; i++) {
-      this.runningTasks.push(this.runTask());
+      const errorChannel = new TaskErrorChannel();
+      const taskRunner = new TaskRunner(i, errorChannel, () => this.runTask());
+
+      this.runningTasks.push(taskRunner.run());
+
+      errorChannel.onError((event) => {
+        const taskRunner = new TaskRunner(event.taskIndex, errorChannel, () => this.runTask());
+        this.runningTasks[event.taskIndex] = taskRunner.run();
+      });
     }
   }
 
   async stop(): Promise<void> {
     this.stopRequested = true;
 
-    const results = await Promise.allSettled(this.runningTasks);
+    await Promise.allSettled(this.runningTasks);
   }
 
   async runTask(): Promise<void> {
     while (!this.stopRequested) {
       const task = await this.datastore.claim({ kind: this.taskKind });
 
-      // If no tasks are available, wait a bit before trying again
+      // If no tasks are available, wait before trying again
       if (!task) {
-        // TODO: get from config (eg. idleInterval)
-        await setTimeout(5000);
+        await setTimeout(this.idleIntervalMs);
 
         continue;
       }
 
       // Process the task using the handler
       await this.handleTask(task);
+
+      // Wait a bit before claiming the next task
+      await setTimeout(this.claimIntervalMs);
     }
   }
 
@@ -66,9 +84,6 @@ export class SimpleProcessor<TaskKind, TaskData, DatastoreOptions> extends Event
         task: completedTask,
         timestamp: completedTask.completedAt,
       });
-
-      // Wait a bit before claiming the next task
-      await setTimeout(150);
     } catch (error) {
       await this.datastore.fail(task.id, error as Error);
       this.emit('task-failed', {


### PR DESCRIPTION
### Description
1. Implemented **Chrono** 's`start` and `stop` method. Currently it just calls the `Processor.(start|stop)` methods respectively.
2. Added `TaskRunner` class for better error handling and task recovery when task fails unexpectedly.