### PR TITLE
process task with timeout

### DIFF
--- a/examples/sample-memory-datastore-app/src/main.ts
+++ b/examples/sample-memory-datastore-app/src/main.ts
@@ -29,8 +29,8 @@ async function main() {
 
   // you can attach event listeners to the processors
   const taskCompletions = [
-    new Promise((resolve) => processor1.once('task-completed', resolve)),
-    new Promise((resolve) => processor2.once('task-completed', resolve)),
+    new Promise((resolve) => processor1.once('task.completed', resolve)),
+    new Promise((resolve) => processor2.once('task.completed', resolve)),
   ];
 
   // Start the Chrono instance

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -72,11 +72,11 @@ export class Chrono<TaskMapping extends TaskMappingBase, DatastoreOptions> exten
         datastoreOptions: input.datastoreOptions,
       });
 
-      this.emit('task-scheduled', { task, timestamp: new Date() });
+      this.emit('task.scheduled', { task, timestamp: new Date() });
 
       return task;
     } catch (error) {
-      this.emit('task-schedule-failed', {
+      this.emit('task.schedule.failed', {
         error,
         input,
         timestamp: new Date(),

--- a/packages/chrono-core/src/datastore.ts
+++ b/packages/chrono-core/src/datastore.ts
@@ -1,4 +1,4 @@
-import type { TaskMappingBase } from '.';
+import type { TaskMappingBase } from './chrono';
 
 export const TaskStatus = {
   PENDING: 'PENDING',

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, vitest } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { Chrono } from '../../src/chrono';
-import type { Datastore, Task } from '../../src/datastore';
+import { type Datastore, type Task, TaskStatus } from '../../src/datastore';
 
 describe('Chrono', () => {
   type TaskData = { someField: number };
@@ -11,8 +11,7 @@ describe('Chrono', () => {
     'send-test-task': TaskData;
   };
   type DatastoreOptions = Record<string, unknown>;
-
-  const mockDatastore = mock<Datastore<keyof TaskMapping, TaskData, DatastoreOptions>>();
+  const mockDatastore = mock<Datastore<TaskMapping, DatastoreOptions>>();
 
   const chrono = new Chrono<TaskMapping, DatastoreOptions>(mockDatastore);
 
@@ -46,7 +45,7 @@ describe('Chrono', () => {
     const mockScheduleOutput: Task<keyof TaskMapping, TaskData> = {
       id: faker.string.nanoid(),
       kind: 'send-test-task',
-      status: 'pending',
+      status: TaskStatus.PENDING,
       data: { someField: 1 },
       priority: 0,
       idempotencyKey: faker.string.nanoid(),
@@ -95,7 +94,7 @@ describe('Chrono', () => {
       });
 
       expect(emitSpy).toHaveBeenCalledOnce();
-      expect(emitSpy).toHaveBeenCalledWith('task-scheduled', {
+      expect(emitSpy).toHaveBeenCalledWith('task.scheduled', {
         task: mockScheduleOutput,
         timestamp: expect.any(Date),
       });
@@ -117,7 +116,7 @@ describe('Chrono', () => {
       await expect(chrono.scheduleTask(mockScheduleTaskInput)).rejects.toThrow('Failed to schedule task');
 
       expect(emitSpy).toHaveBeenCalledOnce();
-      expect(emitSpy).toHaveBeenCalledWith('task-schedule-failed', {
+      expect(emitSpy).toHaveBeenCalledWith('task.schedule.failed', {
         error: mockDatastoreError,
         input: mockScheduleTaskInput,
         timestamp: expect.any(Date),


### PR DESCRIPTION
### Description
1. Added timeout when processing task.
2. Separated error handling when processing task and marking task as completed.

_Others:_
- Aligned event names to use dot-notation (eg. `task.completed`).