### PR TITLE
Mongo Indexes, new constructor, unclaim

### DIFF
--- a/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
+++ b/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
@@ -4,8 +4,8 @@ import {
   type Task,
   type TaskMappingBase,
   TaskStatus,
-} from "@neofinancial/chrono-core";
-import type { ClaimTaskInput } from "@neofinancial/chrono-core/build/datastore";
+} from '@neofinancial/chrono-core';
+import type { ClaimTaskInput } from '@neofinancial/chrono-core/build/datastore';
 import {
   type ClientSession,
   type Collection,
@@ -14,10 +14,10 @@ import {
   type OptionalId,
   type UpdateFilter,
   type WithId,
-} from "mongodb";
-import { IndexNames, ensureIndexes } from "./mongo-indexes";
+} from 'mongodb';
+import { IndexNames, ensureIndexes } from './mongo-indexes';
 
-const DEFAULT_COLLECTION_NAME = "chrono-tasks";
+const DEFAULT_COLLECTION_NAME = 'chrono-tasks';
 const DEFAULT_COMPLETED_DOCUMENT_TTL = 60 * 60 * 24; // 1 day
 const DEFAULT_CLAIM_STALE_TIMEOUT = 10_000; // 10 seconds
 
@@ -31,9 +31,7 @@ export type MongoDatastoreOptions = {
   session?: ClientSession;
 };
 
-export type TaskDocument<TaskKind, TaskData> = WithId<
-  Omit<Task<TaskKind, TaskData>, "id">
->;
+export type TaskDocument<TaskKind, TaskData> = WithId<Omit<Task<TaskKind, TaskData>, 'id'>>;
 
 export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
   implements Datastore<TaskMapping, MongoDatastoreOptions>
@@ -44,36 +42,29 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
   private constructor(database: Db, config?: ChronoMongoDatastoreConfig) {
     this.database = database;
     this.config = {
-      completedDocumentTTL:
-        config?.completedDocumentTTL || DEFAULT_COMPLETED_DOCUMENT_TTL,
-      claimStaleTimeout:
-        config?.claimStaleTimeout || DEFAULT_CLAIM_STALE_TIMEOUT,
+      completedDocumentTTL: config?.completedDocumentTTL || DEFAULT_COMPLETED_DOCUMENT_TTL,
+      claimStaleTimeout: config?.claimStaleTimeout || DEFAULT_CLAIM_STALE_TIMEOUT,
       collectionName: config?.collectionName || DEFAULT_COLLECTION_NAME,
     };
   }
 
   static async create<TaskMapping extends TaskMappingBase>(
     database: Db,
-    config?: ChronoMongoDatastoreConfig
+    config?: ChronoMongoDatastoreConfig,
   ): Promise<ChronoMongoDatastore<TaskMapping>> {
     const datastore = new ChronoMongoDatastore<TaskMapping>(database, config);
 
-    await ensureIndexes(
-      datastore.database.collection(datastore.config.collectionName),
-      {
-        completedDocumentTTL: datastore.config.completedDocumentTTL,
-      }
-    );
+    await ensureIndexes(datastore.database.collection(datastore.config.collectionName), {
+      completedDocumentTTL: datastore.config.completedDocumentTTL,
+    });
 
     return datastore;
   }
 
   async schedule<TaskKind extends keyof TaskMapping>(
-    input: ScheduleInput<TaskKind, TaskMapping[TaskKind], MongoDatastoreOptions>
+    input: ScheduleInput<TaskKind, TaskMapping[TaskKind], MongoDatastoreOptions>,
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]>> {
-    const createInput: OptionalId<
-      TaskDocument<TaskKind, TaskMapping[TaskKind]>
-    > = {
+    const createInput: OptionalId<TaskDocument<TaskKind, TaskMapping[TaskKind]>> = {
       kind: input.kind,
       status: TaskStatus.PENDING,
       data: input.data,
@@ -85,14 +76,10 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     };
 
     try {
-      const results = await this.database
-        .collection(this.config.collectionName)
-        .insertOne(createInput, {
-          ...(input?.datastoreOptions?.session
-            ? { session: input.datastoreOptions.session }
-            : undefined),
-          ignoreUndefined: true,
-        });
+      const results = await this.database.collection(this.config.collectionName).insertOne(createInput, {
+        ...(input?.datastoreOptions?.session ? { session: input.datastoreOptions.session } : undefined),
+        ignoreUndefined: true,
+      });
 
       if (results.acknowledged) {
         return this.toObject({ _id: results.insertedId, ...createInput });
@@ -101,7 +88,7 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
       if (
         input.idempotencyKey &&
         error instanceof Error &&
-        "code" in error &&
+        'code' in error &&
         (error.code === 11000 || error.code === 11001)
       ) {
         const existingTask = await this.collection<TaskKind>().findOne(
@@ -110,10 +97,8 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
           },
           {
             hint: IndexNames.IDEMPOTENCY_KEY_INDEX,
-            ...(input.datastoreOptions?.session
-              ? { session: input.datastoreOptions.session }
-              : undefined),
-          }
+            ...(input.datastoreOptions?.session ? { session: input.datastoreOptions.session } : undefined),
+          },
         );
 
         if (existingTask) {
@@ -121,7 +106,7 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
         }
 
         throw new Error(
-          `Failed to find existing task with idempotency key ${input.idempotencyKey} despite unique index error`
+          `Failed to find existing task with idempotency key ${input.idempotencyKey} despite unique index error`,
         );
       }
       throw error;
@@ -131,7 +116,7 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
   }
 
   async claim<TaskKind extends Extract<keyof TaskMapping, string>>(
-    input: ClaimTaskInput<TaskKind>
+    input: ClaimTaskInput<TaskKind>,
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]> | undefined> {
     const now = new Date();
     const task = await this.collection<TaskKind>().findOneAndUpdate(
@@ -152,8 +137,8 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
       {
         sort: { priority: -1, scheduledAt: 1 },
         // hint: IndexNames.CLAIM_DOCUMENT_INDEX as unknown as Document,
-        returnDocument: "after",
-      }
+        returnDocument: 'after',
+      },
     );
 
     return task ? this.toObject(task) : undefined;
@@ -161,7 +146,7 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
 
   async unclaim<TaskKind extends keyof TaskMapping>(
     taskId: string,
-    nextScheduledAt: Date
+    nextScheduledAt: Date,
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]>> {
     const taskDocument = await this.updateOrThrow<TaskKind>(taskId, {
       $set: {
@@ -176,9 +161,7 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     return this.toObject(taskDocument);
   }
 
-  async complete<TaskKind extends keyof TaskMapping>(
-    taskId: string
-  ): Promise<Task<TaskKind, TaskMapping[TaskKind]>> {
+  async complete<TaskKind extends keyof TaskMapping>(taskId: string): Promise<Task<TaskKind, TaskMapping[TaskKind]>> {
     const now = new Date();
 
     const task = await this.updateOrThrow<TaskKind>(taskId, {
@@ -192,9 +175,7 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     return this.toObject(task);
   }
 
-  async fail<TaskKind extends keyof TaskMapping>(
-    taskId: string
-  ): Promise<Task<TaskKind, TaskMapping[TaskKind]>> {
+  async fail<TaskKind extends keyof TaskMapping>(taskId: string): Promise<Task<TaskKind, TaskMapping[TaskKind]>> {
     const now = new Date();
 
     const task = await this.updateOrThrow<TaskKind>(taskId, {
@@ -209,31 +190,23 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
 
   private async updateOrThrow<TaskKind extends keyof TaskMapping>(
     taskId: string,
-    update: UpdateFilter<TaskDocument<TaskKind, TaskMapping[TaskKind]>>
+    update: UpdateFilter<TaskDocument<TaskKind, TaskMapping[TaskKind]>>,
   ): Promise<TaskDocument<TaskKind, TaskMapping[TaskKind]>> {
-    const document = await this.collection<TaskKind>().findOneAndUpdate(
-      { _id: new ObjectId(taskId) },
-      update,
-      {
-        returnDocument: "after",
-      }
-    );
+    const document = await this.collection<TaskKind>().findOneAndUpdate({ _id: new ObjectId(taskId) }, update, {
+      returnDocument: 'after',
+    });
     if (!document) {
       throw new Error(`Task with ID ${taskId} not found`);
     }
     return document;
   }
 
-  private collection<TaskKind extends keyof TaskMapping>(): Collection<
-    TaskDocument<TaskKind, TaskMapping[TaskKind]>
-  > {
-    return this.database.collection<
-      TaskDocument<TaskKind, TaskMapping[TaskKind]>
-    >(this.config.collectionName);
+  private collection<TaskKind extends keyof TaskMapping>(): Collection<TaskDocument<TaskKind, TaskMapping[TaskKind]>> {
+    return this.database.collection<TaskDocument<TaskKind, TaskMapping[TaskKind]>>(this.config.collectionName);
   }
 
   private toObject<TaskKind extends keyof TaskMapping>(
-    document: TaskDocument<TaskKind, TaskMapping[TaskKind]>
+    document: TaskDocument<TaskKind, TaskMapping[TaskKind]>,
   ): Task<TaskKind, TaskMapping[TaskKind]> {
     return {
       id: document._id.toHexString(),

--- a/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
+++ b/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
@@ -18,13 +18,12 @@ import {
 import { IndexNames, ensureIndexes } from './mongo-indexes';
 
 const DEFAULT_COLLECTION_NAME = 'chrono-tasks';
-const DEFAULT_COMPLETED_DOCUMENT_TTL = 60 * 60 * 24; // 1 day
 const DEFAULT_CLAIM_STALE_TIMEOUT = 10_000; // 10 seconds
 
 export type ChronoMongoDatastoreConfig = {
   completedDocumentTTL?: number;
-  collectionName?: string;
-  claimStaleTimeout?: number;
+  collectionName: string;
+  claimStaleTimeout: number;
 };
 
 export type MongoDatastoreOptions = {
@@ -36,13 +35,13 @@ export type TaskDocument<TaskKind, TaskData> = WithId<Omit<Task<TaskKind, TaskDa
 export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
   implements Datastore<TaskMapping, MongoDatastoreOptions>
 {
-  private config: Required<ChronoMongoDatastoreConfig>;
+  private config: ChronoMongoDatastoreConfig;
   private database: Db;
 
-  private constructor(database: Db, config?: ChronoMongoDatastoreConfig) {
+  private constructor(database: Db, config?: Partial<ChronoMongoDatastoreConfig>) {
     this.database = database;
     this.config = {
-      completedDocumentTTL: config?.completedDocumentTTL || DEFAULT_COMPLETED_DOCUMENT_TTL,
+      completedDocumentTTL: config?.completedDocumentTTL,
       claimStaleTimeout: config?.claimStaleTimeout || DEFAULT_CLAIM_STALE_TIMEOUT,
       collectionName: config?.collectionName || DEFAULT_COLLECTION_NAME,
     };
@@ -50,7 +49,7 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
 
   static async create<TaskMapping extends TaskMappingBase>(
     database: Db,
-    config?: ChronoMongoDatastoreConfig,
+    config?: Partial<ChronoMongoDatastoreConfig>,
   ): Promise<ChronoMongoDatastore<TaskMapping>> {
     const datastore = new ChronoMongoDatastore<TaskMapping>(database, config);
 

--- a/packages/chrono-mongo-datastore/src/mongo-indexes.ts
+++ b/packages/chrono-mongo-datastore/src/mongo-indexes.ts
@@ -1,0 +1,38 @@
+import { TaskStatus } from '@neofinancial/chrono-core';
+import type { Collection } from 'mongodb';
+
+export const DEFAULT_COMPLETED_DOCUMENT_TTL = 60 * 60 * 24 * 30; // 30 days
+
+export const IndexNames = {
+  COMPLETED_DOCUMENT_TTL_INDEX: 'chrono-completed-document-ttl-index',
+  CLAIM_DOCUMENT_INDEX: 'chrono-claim-document-index',
+  IDEMPOTENCY_KEY_INDEX: 'chrono-idempotency-key-index',
+};
+
+export type IndexDefinitionOptions = {
+  completedDocumentTTL?: number;
+};
+
+export async function ensureIndexes(collection: Collection, options: IndexDefinitionOptions): Promise<void> {
+  await collection.createIndex(
+    { completedAt: -1 },
+    {
+      partialFilterExpression: {
+        completedAt: { $exists: true },
+        status: { $eq: TaskStatus.COMPLETED },
+      },
+      expireAfterSeconds: options.completedDocumentTTL || DEFAULT_COMPLETED_DOCUMENT_TTL,
+      name: IndexNames.COMPLETED_DOCUMENT_TTL_INDEX,
+    },
+  );
+
+  await collection.createIndex(
+    { kind: 1, status: 1, scheduledAt: 1, priority: -1, claimedAt: 1 },
+    { name: IndexNames.CLAIM_DOCUMENT_INDEX },
+  );
+
+  await collection.createIndex(
+    { idempotencyKey: 1 },
+    { name: IndexNames.IDEMPOTENCY_KEY_INDEX, unique: true, sparse: true },
+  );
+}

--- a/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
+++ b/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
@@ -1,21 +1,10 @@
-import { faker } from "@faker-js/faker";
-import { TaskStatus } from "@neofinancial/chrono-core";
-import { type Collection, MongoClient, ObjectId } from "mongodb";
-import {
-  afterAll,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  test,
-  vitest,
-} from "vitest";
+import { faker } from '@faker-js/faker';
+import { TaskStatus } from '@neofinancial/chrono-core';
+import { type Collection, MongoClient, ObjectId } from 'mongodb';
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vitest } from 'vitest';
 
-import {
-  ChronoMongoDatastore,
-  type TaskDocument,
-} from "../../src/chrono-mongo-datastore";
-import { DB_NAME } from "../database-setup";
+import { ChronoMongoDatastore, type TaskDocument } from '../../src/chrono-mongo-datastore';
+import { DB_NAME } from '../database-setup';
 
 type TaskMapping = {
   test: {
@@ -23,18 +12,16 @@ type TaskMapping = {
   };
 };
 
-const TEST_DB_COLLECTION_NAME = "test_tasks";
+const TEST_DB_COLLECTION_NAME = 'test_tasks';
 const TEST_CLAIM_STALE_TIMEOUT = 1000; // 1 second
 
-describe("ChronoMongoDatastore", () => {
+describe('ChronoMongoDatastore', () => {
   let mongoClient: MongoClient;
-  let collection: Collection<
-    TaskDocument<keyof TaskMapping, TaskMapping[keyof TaskMapping]>
-  >;
+  let collection: Collection<TaskDocument<keyof TaskMapping, TaskMapping[keyof TaskMapping]>>;
   let dataStore: ChronoMongoDatastore<TaskMapping>;
 
   beforeAll(async () => {
-    mongoClient = new MongoClient("mongodb://localhost:27017");
+    mongoClient = new MongoClient('mongodb://localhost:27017');
     await mongoClient.connect();
 
     collection = mongoClient.db(DB_NAME).collection(TEST_DB_COLLECTION_NAME);
@@ -53,33 +40,33 @@ describe("ChronoMongoDatastore", () => {
     await mongoClient.close();
   });
 
-  describe("schedule", () => {
-    describe("when called with valid input", () => {
+  describe('schedule', () => {
+    describe('when called with valid input', () => {
       const input = {
-        kind: "test" as const,
-        data: { test: "test" },
+        kind: 'test' as const,
+        data: { test: 'test' },
         priority: 1,
         when: new Date(),
       };
 
-      test("should return task with correct properties", async () => {
+      test('should return task with correct properties', async () => {
         const task = await dataStore.schedule(input);
 
         expect(task).toEqual(
           expect.objectContaining({
             kind: input.kind,
-            status: "PENDING",
+            status: 'PENDING',
             data: input.data,
             priority: input.priority,
             originalScheduleDate: expect.any(Date),
             scheduledAt: expect.any(Date),
             id: expect.any(String),
             retryCount: 0,
-          })
+          }),
         );
       });
 
-      test("should store task in the database", async () => {
+      test('should store task in the database', async () => {
         const task = await dataStore.schedule(input);
 
         const storedTask = await collection.findOne({
@@ -89,23 +76,23 @@ describe("ChronoMongoDatastore", () => {
         expect(storedTask).toEqual(
           expect.objectContaining({
             kind: input.kind,
-            status: "PENDING",
+            status: 'PENDING',
             data: input.data,
             priority: input.priority,
             originalScheduleDate: expect.any(Date),
             scheduledAt: expect.any(Date),
             retryCount: 0,
-          })
+          }),
         );
       });
     });
 
-    describe("idempotency", () => {
-      test("should return existing task if one exists with same idepotency key", async () => {
+    describe('idempotency', () => {
+      test('should return existing task if one exists with same idepotency key', async () => {
         const idempotencyKey = faker.string.uuid();
         const input = {
-          kind: "test" as const,
-          data: { test: "test" },
+          kind: 'test' as const,
+          data: { test: 'test' },
           priority: 1,
           when: new Date(),
           idempotencyKey,
@@ -119,15 +106,15 @@ describe("ChronoMongoDatastore", () => {
     });
   });
 
-  describe("claim", () => {
+  describe('claim', () => {
     const input = {
-      kind: "test" as const,
-      data: { test: "test" },
+      kind: 'test' as const,
+      data: { test: 'test' },
       priority: 1,
       when: new Date(Date.now() - 1),
     };
 
-    test("should claim task in PENDING state with scheduledAt in the past", async () => {
+    test('should claim task in PENDING state with scheduledAt in the past', async () => {
       const task = await dataStore.schedule({
         ...input,
         when: new Date(Date.now() - 1000),
@@ -139,12 +126,12 @@ describe("ChronoMongoDatastore", () => {
         expect.objectContaining({
           id: task.id,
           kind: task.kind,
-          status: "CLAIMED",
-        })
+          status: 'CLAIMED',
+        }),
       );
     });
 
-    test("should claim task in CLAIMED state with claimedAt in the past", async () => {
+    test('should claim task in CLAIMED state with claimedAt in the past', async () => {
       const scheduledTask = await dataStore.schedule(input);
 
       const claimedTask = await dataStore.claim({
@@ -156,13 +143,7 @@ describe("ChronoMongoDatastore", () => {
       });
 
       const fakeTimer = vitest.useFakeTimers();
-      fakeTimer.setSystemTime(
-        new Date(
-          (claimedTask?.claimedAt?.getTime() as number) +
-            TEST_CLAIM_STALE_TIMEOUT +
-            1
-        )
-      );
+      fakeTimer.setSystemTime(new Date((claimedTask?.claimedAt?.getTime() as number) + TEST_CLAIM_STALE_TIMEOUT + 1));
 
       const claimedTaskAgainAgain = await dataStore.claim({
         kind: input.kind,
@@ -172,14 +153,14 @@ describe("ChronoMongoDatastore", () => {
       expect(scheduledTask).toEqual(
         expect.objectContaining({
           status: TaskStatus.PENDING,
-        })
+        }),
       );
       expect(claimedTask).toEqual(
         expect.objectContaining({
           id: scheduledTask.id,
           kind: scheduledTask.kind,
           status: TaskStatus.CLAIMED,
-        })
+        }),
       );
       expect(claimedTaskAgain).toBeUndefined();
       expect(claimedTaskAgainAgain).toEqual(
@@ -187,11 +168,11 @@ describe("ChronoMongoDatastore", () => {
           id: scheduledTask.id,
           kind: scheduledTask.kind,
           status: TaskStatus.CLAIMED,
-        })
+        }),
       );
     });
 
-    test("should only be able to claim 1 task at a time", async () => {
+    test('should only be able to claim 1 task at a time', async () => {
       const task1 = await dataStore.schedule(input);
       const task2 = await dataStore.schedule(input);
 
@@ -211,19 +192,19 @@ describe("ChronoMongoDatastore", () => {
       expect(claimedTasks.filter(Boolean).length).toEqual(2);
 
       expect(claimedTasks.find((task) => task?.id === task1.id)).toEqual(
-        expect.objectContaining({ id: task1.id, status: TaskStatus.CLAIMED })
+        expect.objectContaining({ id: task1.id, status: TaskStatus.CLAIMED }),
       );
       expect(claimedTasks.find((task) => task?.id === task2.id)).toEqual(
-        expect.objectContaining({ id: task2.id, status: TaskStatus.CLAIMED })
+        expect.objectContaining({ id: task2.id, status: TaskStatus.CLAIMED }),
       );
     });
   });
 
-  describe("complete", () => {
-    test("should mark task as completed", async () => {
+  describe('complete', () => {
+    test('should mark task as completed', async () => {
       const task = await dataStore.schedule({
-        kind: "test",
-        data: { test: "test" },
+        kind: 'test',
+        data: { test: 'test' },
         priority: 1,
         when: new Date(),
       });
@@ -238,7 +219,7 @@ describe("ChronoMongoDatastore", () => {
           kind: task.kind,
           status: TaskStatus.COMPLETED,
           completedAt: expect.any(Date),
-        })
+        }),
       );
       expect(completedTask).toEqual(
         expect.objectContaining({
@@ -246,24 +227,22 @@ describe("ChronoMongoDatastore", () => {
           kind: task.kind,
           status: TaskStatus.COMPLETED,
           completedAt: expect.any(Date),
-        })
+        }),
       );
     });
 
-    test("should throw an error if task is not found", async () => {
+    test('should throw an error if task is not found', async () => {
       const taskId = faker.database.mongodbObjectId();
 
-      await expect(() => dataStore.complete(taskId)).rejects.toThrow(
-        `Task with ID ${taskId} not found`
-      );
+      await expect(() => dataStore.complete(taskId)).rejects.toThrow(`Task with ID ${taskId} not found`);
     });
   });
 
-  describe("fail", () => {
-    test("should mark task as failed", async () => {
+  describe('fail', () => {
+    test('should mark task as failed', async () => {
       const task = await dataStore.schedule({
-        kind: "test",
-        data: { test: "test" },
+        kind: 'test',
+        data: { test: 'test' },
         priority: 1,
         when: new Date(),
       });
@@ -277,34 +256,32 @@ describe("ChronoMongoDatastore", () => {
         expect.objectContaining({
           kind: task.kind,
           status: TaskStatus.FAILED,
-        })
+        }),
       );
       expect(failedTask).toEqual(
         expect.objectContaining({
           id: task.id,
           kind: task.kind,
           status: TaskStatus.FAILED,
-        })
+        }),
       );
     });
 
-    test("should throw an error if task is not found", async () => {
+    test('should throw an error if task is not found', async () => {
       const taskId = faker.database.mongodbObjectId();
 
-      await expect(() => dataStore.fail(taskId)).rejects.toThrow(
-        `Task with ID ${taskId} not found`
-      );
+      await expect(() => dataStore.fail(taskId)).rejects.toThrow(`Task with ID ${taskId} not found`);
     });
   });
 
-  describe("unclaim", () => {
-    test("should unclaim task", async () => {
+  describe('unclaim', () => {
+    test('should unclaim task', async () => {
       const firstScheduleDate = faker.date.past();
       const secondScheduleDate = faker.date.past();
 
       const task = await dataStore.schedule({
-        kind: "test",
-        data: { test: "test" },
+        kind: 'test',
+        data: { test: 'test' },
         priority: 1,
         when: firstScheduleDate,
       });
@@ -315,13 +292,10 @@ describe("ChronoMongoDatastore", () => {
           retryCount: 0,
           scheduledAt: firstScheduleDate,
           originalScheduleDate: firstScheduleDate,
-        })
+        }),
       );
 
-      const unclaimedTask = await dataStore.unclaim(
-        task.id,
-        secondScheduleDate
-      );
+      const unclaimedTask = await dataStore.unclaim(task.id, secondScheduleDate);
       const taskDocument = await collection.findOne({
         _id: new ObjectId(task.id),
       });
@@ -333,7 +307,7 @@ describe("ChronoMongoDatastore", () => {
           scheduledAt: secondScheduleDate,
           originalScheduleDate: firstScheduleDate,
           retryCount: 1,
-        })
+        }),
       );
       expect(unclaimedTask).toEqual(
         expect.objectContaining({
@@ -343,7 +317,7 @@ describe("ChronoMongoDatastore", () => {
           scheduledAt: secondScheduleDate,
           originalScheduleDate: firstScheduleDate,
           retryCount: 1,
-        })
+        }),
       );
     });
   });

--- a/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
+++ b/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
@@ -1,10 +1,21 @@
-import { faker } from '@faker-js/faker';
-import { TaskStatus } from '@neofinancial/chrono-core';
-import { type Collection, MongoClient, ObjectId } from 'mongodb';
-import { afterAll, beforeAll, beforeEach, describe, expect, test, vitest } from 'vitest';
+import { faker } from "@faker-js/faker";
+import { TaskStatus } from "@neofinancial/chrono-core";
+import { type Collection, MongoClient, ObjectId } from "mongodb";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vitest,
+} from "vitest";
 
-import { ChronoMongoDatastore, type TaskDocument } from '../../src/chrono-mongo-datastore';
-import { DB_NAME } from '../database-setup';
+import {
+  ChronoMongoDatastore,
+  type TaskDocument,
+} from "../../src/chrono-mongo-datastore";
+import { DB_NAME } from "../database-setup";
 
 type TaskMapping = {
   test: {
@@ -12,16 +23,18 @@ type TaskMapping = {
   };
 };
 
-const TEST_DB_COLLECTION_NAME = 'test_tasks';
+const TEST_DB_COLLECTION_NAME = "test_tasks";
 const TEST_CLAIM_STALE_TIMEOUT = 1000; // 1 second
 
-describe('ChronoMongoDatastore', () => {
+describe("ChronoMongoDatastore", () => {
   let mongoClient: MongoClient;
-  let collection: Collection<TaskDocument<keyof TaskMapping, TaskMapping[keyof TaskMapping]>>;
+  let collection: Collection<
+    TaskDocument<keyof TaskMapping, TaskMapping[keyof TaskMapping]>
+  >;
   let dataStore: ChronoMongoDatastore<TaskMapping>;
 
   beforeAll(async () => {
-    mongoClient = new MongoClient('mongodb://localhost:27017');
+    mongoClient = new MongoClient("mongodb://localhost:27017");
     await mongoClient.connect();
 
     collection = mongoClient.db(DB_NAME).collection(TEST_DB_COLLECTION_NAME);
@@ -40,33 +53,33 @@ describe('ChronoMongoDatastore', () => {
     await mongoClient.close();
   });
 
-  describe('schedule', () => {
-    describe('when called with valid input', () => {
+  describe("schedule", () => {
+    describe("when called with valid input", () => {
       const input = {
-        kind: 'test' as const,
-        data: { test: 'test' },
+        kind: "test" as const,
+        data: { test: "test" },
         priority: 1,
         when: new Date(),
       };
 
-      test('should return task with correct properties', async () => {
+      test("should return task with correct properties", async () => {
         const task = await dataStore.schedule(input);
 
         expect(task).toEqual(
           expect.objectContaining({
             kind: input.kind,
-            status: 'PENDING',
+            status: "PENDING",
             data: input.data,
             priority: input.priority,
             originalScheduleDate: expect.any(Date),
             scheduledAt: expect.any(Date),
             id: expect.any(String),
             retryCount: 0,
-          }),
+          })
         );
       });
 
-      test('should store task in the database', async () => {
+      test("should store task in the database", async () => {
         const task = await dataStore.schedule(input);
 
         const storedTask = await collection.findOne({
@@ -76,27 +89,45 @@ describe('ChronoMongoDatastore', () => {
         expect(storedTask).toEqual(
           expect.objectContaining({
             kind: input.kind,
-            status: 'PENDING',
+            status: "PENDING",
             data: input.data,
             priority: input.priority,
             originalScheduleDate: expect.any(Date),
             scheduledAt: expect.any(Date),
             retryCount: 0,
-          }),
+          })
         );
+      });
+    });
+
+    describe("idempotency", () => {
+      test("should return existing task if one exists with same idepotency key", async () => {
+        const idempotencyKey = faker.string.uuid();
+        const input = {
+          kind: "test" as const,
+          data: { test: "test" },
+          priority: 1,
+          when: new Date(),
+          idempotencyKey,
+        };
+
+        const task1 = await dataStore.schedule(input);
+        const task2 = await dataStore.schedule(input);
+
+        expect(task1).toEqual(task2);
       });
     });
   });
 
-  describe('claim', () => {
+  describe("claim", () => {
     const input = {
-      kind: 'test' as const,
-      data: { test: 'test' },
+      kind: "test" as const,
+      data: { test: "test" },
       priority: 1,
       when: new Date(Date.now() - 1),
     };
 
-    test('should claim task in PENDING state with scheduledAt in the past', async () => {
+    test("should claim task in PENDING state with scheduledAt in the past", async () => {
       const task = await dataStore.schedule({
         ...input,
         when: new Date(Date.now() - 1000),
@@ -108,12 +139,12 @@ describe('ChronoMongoDatastore', () => {
         expect.objectContaining({
           id: task.id,
           kind: task.kind,
-          status: 'CLAIMED',
-        }),
+          status: "CLAIMED",
+        })
       );
     });
 
-    test('should claim task in CLAIMED state with claimedAt in the past', async () => {
+    test("should claim task in CLAIMED state with claimedAt in the past", async () => {
       const scheduledTask = await dataStore.schedule(input);
 
       const claimedTask = await dataStore.claim({
@@ -125,7 +156,13 @@ describe('ChronoMongoDatastore', () => {
       });
 
       const fakeTimer = vitest.useFakeTimers();
-      fakeTimer.setSystemTime(new Date((claimedTask?.claimedAt?.getTime() as number) + TEST_CLAIM_STALE_TIMEOUT + 1));
+      fakeTimer.setSystemTime(
+        new Date(
+          (claimedTask?.claimedAt?.getTime() as number) +
+            TEST_CLAIM_STALE_TIMEOUT +
+            1
+        )
+      );
 
       const claimedTaskAgainAgain = await dataStore.claim({
         kind: input.kind,
@@ -135,14 +172,14 @@ describe('ChronoMongoDatastore', () => {
       expect(scheduledTask).toEqual(
         expect.objectContaining({
           status: TaskStatus.PENDING,
-        }),
+        })
       );
       expect(claimedTask).toEqual(
         expect.objectContaining({
           id: scheduledTask.id,
           kind: scheduledTask.kind,
           status: TaskStatus.CLAIMED,
-        }),
+        })
       );
       expect(claimedTaskAgain).toBeUndefined();
       expect(claimedTaskAgainAgain).toEqual(
@@ -150,11 +187,11 @@ describe('ChronoMongoDatastore', () => {
           id: scheduledTask.id,
           kind: scheduledTask.kind,
           status: TaskStatus.CLAIMED,
-        }),
+        })
       );
     });
 
-    test('should only be able to claim 1 task at a time', async () => {
+    test("should only be able to claim 1 task at a time", async () => {
       const task1 = await dataStore.schedule(input);
       const task2 = await dataStore.schedule(input);
 
@@ -174,19 +211,19 @@ describe('ChronoMongoDatastore', () => {
       expect(claimedTasks.filter(Boolean).length).toEqual(2);
 
       expect(claimedTasks.find((task) => task?.id === task1.id)).toEqual(
-        expect.objectContaining({ id: task1.id, status: TaskStatus.CLAIMED }),
+        expect.objectContaining({ id: task1.id, status: TaskStatus.CLAIMED })
       );
       expect(claimedTasks.find((task) => task?.id === task2.id)).toEqual(
-        expect.objectContaining({ id: task2.id, status: TaskStatus.CLAIMED }),
+        expect.objectContaining({ id: task2.id, status: TaskStatus.CLAIMED })
       );
     });
   });
 
-  describe('complete', () => {
-    test('should mark task as completed', async () => {
+  describe("complete", () => {
+    test("should mark task as completed", async () => {
       const task = await dataStore.schedule({
-        kind: 'test',
-        data: { test: 'test' },
+        kind: "test",
+        data: { test: "test" },
         priority: 1,
         when: new Date(),
       });
@@ -201,7 +238,7 @@ describe('ChronoMongoDatastore', () => {
           kind: task.kind,
           status: TaskStatus.COMPLETED,
           completedAt: expect.any(Date),
-        }),
+        })
       );
       expect(completedTask).toEqual(
         expect.objectContaining({
@@ -209,22 +246,24 @@ describe('ChronoMongoDatastore', () => {
           kind: task.kind,
           status: TaskStatus.COMPLETED,
           completedAt: expect.any(Date),
-        }),
+        })
       );
     });
 
-    test('should throw an error if task is not found', async () => {
+    test("should throw an error if task is not found", async () => {
       const taskId = faker.database.mongodbObjectId();
 
-      await expect(() => dataStore.complete(taskId)).rejects.toThrow(`Task with ID ${taskId} not found`);
+      await expect(() => dataStore.complete(taskId)).rejects.toThrow(
+        `Task with ID ${taskId} not found`
+      );
     });
   });
 
-  describe('fail', () => {
-    test('should mark task as failed', async () => {
+  describe("fail", () => {
+    test("should mark task as failed", async () => {
       const task = await dataStore.schedule({
-        kind: 'test',
-        data: { test: 'test' },
+        kind: "test",
+        data: { test: "test" },
         priority: 1,
         when: new Date(),
       });
@@ -238,21 +277,74 @@ describe('ChronoMongoDatastore', () => {
         expect.objectContaining({
           kind: task.kind,
           status: TaskStatus.FAILED,
-        }),
+        })
       );
       expect(failedTask).toEqual(
         expect.objectContaining({
           id: task.id,
           kind: task.kind,
           status: TaskStatus.FAILED,
-        }),
+        })
       );
     });
 
-    test('should throw an error if task is not found', async () => {
+    test("should throw an error if task is not found", async () => {
       const taskId = faker.database.mongodbObjectId();
 
-      await expect(() => dataStore.fail(taskId)).rejects.toThrow(`Task with ID ${taskId} not found`);
+      await expect(() => dataStore.fail(taskId)).rejects.toThrow(
+        `Task with ID ${taskId} not found`
+      );
+    });
+  });
+
+  describe("unclaim", () => {
+    test("should unclaim task", async () => {
+      const firstScheduleDate = faker.date.past();
+      const secondScheduleDate = faker.date.past();
+
+      const task = await dataStore.schedule({
+        kind: "test",
+        data: { test: "test" },
+        priority: 1,
+        when: firstScheduleDate,
+      });
+
+      expect(task).toEqual(
+        expect.objectContaining({
+          status: TaskStatus.PENDING,
+          retryCount: 0,
+          scheduledAt: firstScheduleDate,
+          originalScheduleDate: firstScheduleDate,
+        })
+      );
+
+      const unclaimedTask = await dataStore.unclaim(
+        task.id,
+        secondScheduleDate
+      );
+      const taskDocument = await collection.findOne({
+        _id: new ObjectId(task.id),
+      });
+
+      expect(taskDocument).toEqual(
+        expect.objectContaining({
+          kind: task.kind,
+          status: TaskStatus.PENDING,
+          scheduledAt: secondScheduleDate,
+          originalScheduleDate: firstScheduleDate,
+          retryCount: 1,
+        })
+      );
+      expect(unclaimedTask).toEqual(
+        expect.objectContaining({
+          id: task.id,
+          kind: task.kind,
+          status: TaskStatus.PENDING,
+          scheduledAt: secondScheduleDate,
+          originalScheduleDate: firstScheduleDate,
+          retryCount: 1,
+        })
+      );
     });
   });
 });


### PR DESCRIPTION
Setting up mongo indexes 
- could not get hints to work as the types for the hint option requires Document not string. despite the underlying driver taking string. kinda confusing 

Needed new constructor for the async set up of the indexes

Added unclaim logic. Have some ideas around this i would like to run by the team