### PR TITLE
Configurable processor on task handler registration

### DIFF
--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -124,12 +124,6 @@ export class Chrono<TaskMapping extends TaskMappingBase, DatastoreOptions> exten
       configuration: input.processorConfiguration,
     });
 
-    if (processor.getTaskHandlerTimeoutMs() >= this.datastore.getClaimStaleTimeoutMs()) {
-      throw new Error(
-        `Task handler timeout (${processor.getTaskHandlerTimeoutMs()}ms) must be less than the claim stale timeout (${this.datastore.getClaimStaleTimeoutMs()}ms)`,
-      );
-    }
-
     this.processors.set(input.kind, processor);
 
     return processor;

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -13,10 +13,13 @@ export type ScheduleTaskInput<TaskKind, TaskData, DatastoreOptions> = ScheduleIn
   DatastoreOptions
 >;
 
+const DEFAULT_TASK_HANDLER_MAX_CONCURRENCY = 1;
+
 export type RegisterTaskHandlerInput<TaskKind, TaskData> = {
   kind: TaskKind;
   handler: (task: Task<TaskKind, TaskData>) => Promise<void>;
   backoffStrategyOptions?: BackoffStrategyOptions;
+  maxConcurrency?: number;
   claimIntervalMs?: number;
   idleIntervalMs?: number;
   taskHandlerTimeoutMs?: number;
@@ -124,7 +127,7 @@ export class Chrono<TaskMapping extends TaskMappingBase, DatastoreOptions> exten
       datastore: this.datastore,
       handler: input.handler,
       configuration: {
-        maxConcurrency: 1, // TODO: make configurable
+        maxConcurrency: input.maxConcurrency || DEFAULT_TASK_HANDLER_MAX_CONCURRENCY,
         claimIntervalMs: input.claimIntervalMs,
         idleIntervalMs: input.idleIntervalMs,
         taskHandlerTimeoutMs: input.taskHandlerTimeoutMs,

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:stream';
 import type { BackoffStrategyOptions } from './backoff-strategy';
 import type { Datastore, ScheduleInput, Task } from './datastore';
 import { type Processor, createProcessor } from './processors';
+import type { ProcessorConfiguration } from './processors/create-processor';
 import { promiseWithTimeout } from './utils/promise-utils';
 
 export type TaskMappingBase = Record<string, unknown>;
@@ -17,11 +18,7 @@ export type RegisterTaskHandlerInput<TaskKind, TaskData> = {
   kind: TaskKind;
   handler: (task: Task<TaskKind, TaskData>) => Promise<void>;
   backoffStrategyOptions?: BackoffStrategyOptions;
-  maxConcurrency?: number;
-  claimIntervalMs?: number;
-  idleIntervalMs?: number;
-  taskHandlerTimeoutMs?: number;
-  taskHandlerMaxRetries?: number;
+  processorConfiguration?: ProcessorConfiguration;
 };
 
 /**
@@ -124,13 +121,7 @@ export class Chrono<TaskMapping extends TaskMappingBase, DatastoreOptions> exten
       kind: input.kind,
       datastore: this.datastore,
       handler: input.handler,
-      configuration: {
-        maxConcurrency: input.maxConcurrency,
-        claimIntervalMs: input.claimIntervalMs,
-        idleIntervalMs: input.idleIntervalMs,
-        taskHandlerTimeoutMs: input.taskHandlerTimeoutMs,
-        taskHandlerMaxRetries: input.taskHandlerMaxRetries,
-      },
+      configuration: input.processorConfiguration,
     });
 
     if (processor.getTaskHandlerTimeoutMs() >= this.datastore.getClaimStaleTimeoutMs()) {

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -13,8 +13,6 @@ export type ScheduleTaskInput<TaskKind, TaskData, DatastoreOptions> = ScheduleIn
   DatastoreOptions
 >;
 
-const DEFAULT_TASK_HANDLER_MAX_CONCURRENCY = 1;
-
 export type RegisterTaskHandlerInput<TaskKind, TaskData> = {
   kind: TaskKind;
   handler: (task: Task<TaskKind, TaskData>) => Promise<void>;
@@ -127,7 +125,7 @@ export class Chrono<TaskMapping extends TaskMappingBase, DatastoreOptions> exten
       datastore: this.datastore,
       handler: input.handler,
       configuration: {
-        maxConcurrency: input.maxConcurrency || DEFAULT_TASK_HANDLER_MAX_CONCURRENCY,
+        maxConcurrency: input.maxConcurrency,
         claimIntervalMs: input.claimIntervalMs,
         idleIntervalMs: input.idleIntervalMs,
         taskHandlerTimeoutMs: input.taskHandlerTimeoutMs,

--- a/packages/chrono-core/src/datastore.ts
+++ b/packages/chrono-core/src/datastore.ts
@@ -64,4 +64,5 @@ export interface Datastore<TaskMapping extends TaskMappingBase, DatastoreOptions
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;
   complete<TaskKind extends keyof TaskMapping>(taskId: string): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;
   fail<TaskKind extends keyof TaskMapping>(taskId: string): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;
+  getClaimStaleTimeout(): number;
 }

--- a/packages/chrono-core/src/datastore.ts
+++ b/packages/chrono-core/src/datastore.ts
@@ -46,6 +46,7 @@ export type ScheduleInput<TaskKind, TaskData, DatastoreOptions> = {
 
 export type ClaimTaskInput<TaskKind> = {
   kind: TaskKind;
+  claimStaleTimeoutMs: number;
 };
 
 export type DeleteByIdempotencyKeyInput<TaskKind> = {
@@ -80,5 +81,4 @@ export interface Datastore<TaskMapping extends TaskMappingBase, DatastoreOptions
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;
   complete<TaskKind extends keyof TaskMapping>(taskId: string): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;
   fail<TaskKind extends keyof TaskMapping>(taskId: string): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;
-  getClaimStaleTimeoutMs(): number;
 }

--- a/packages/chrono-core/src/datastore.ts
+++ b/packages/chrono-core/src/datastore.ts
@@ -64,5 +64,5 @@ export interface Datastore<TaskMapping extends TaskMappingBase, DatastoreOptions
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;
   complete<TaskKind extends keyof TaskMapping>(taskId: string): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;
   fail<TaskKind extends keyof TaskMapping>(taskId: string): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;
-  getClaimStaleTimeout(): number;
+  getClaimStaleTimeoutMs(): number;
 }

--- a/packages/chrono-core/src/processors/create-processor.ts
+++ b/packages/chrono-core/src/processors/create-processor.ts
@@ -7,6 +7,7 @@ import { SimpleProcessor } from './simple-processor';
 export type ProcessorConfiguration = {
   maxConcurrency?: number;
   claimIntervalMs?: number;
+  claimStaleTimeoutMs?: number;
   idleIntervalMs?: number;
   taskHandlerTimeoutMs?: number;
   taskHandlerMaxRetries?: number;
@@ -40,6 +41,7 @@ export function createProcessor<
     claimIntervalMs: input.configuration?.claimIntervalMs,
     idleIntervalMs: input.configuration?.idleIntervalMs,
     taskHandlerTimeoutMs: input.configuration?.taskHandlerTimeoutMs,
+    claimStaleTimeoutMs: input.configuration?.claimStaleTimeoutMs,
     taskHandlerMaxRetries: input.configuration?.taskHandlerMaxRetries,
   });
 }

--- a/packages/chrono-core/src/processors/create-processor.ts
+++ b/packages/chrono-core/src/processors/create-processor.ts
@@ -20,7 +20,7 @@ export type CreateProcessorInput<
   kind: TaskKind;
   datastore: Datastore<TaskMapping, DatastoreOptions>;
   handler: (task: Task<TaskKind, TaskMapping[TaskKind]>) => Promise<void>;
-  configuration: ProcessorConfiguration;
+  configuration?: ProcessorConfiguration;
   backoffStrategyOptions?: BackoffStrategyOptions;
 };
 
@@ -35,11 +35,11 @@ export function createProcessor<
     datastore: input.datastore,
     kind: input.kind,
     handler: input.handler,
-    maxConcurrency: input.configuration.maxConcurrency,
+    maxConcurrency: input.configuration?.maxConcurrency,
     backoffStrategy,
-    claimIntervalMs: input.configuration.claimIntervalMs,
-    idleIntervalMs: input.configuration.idleIntervalMs,
-    taskHandlerTimeoutMs: input.configuration.taskHandlerTimeoutMs,
-    taskHandlerMaxRetries: input.configuration.taskHandlerMaxRetries,
+    claimIntervalMs: input.configuration?.claimIntervalMs,
+    idleIntervalMs: input.configuration?.idleIntervalMs,
+    taskHandlerTimeoutMs: input.configuration?.taskHandlerTimeoutMs,
+    taskHandlerMaxRetries: input.configuration?.taskHandlerMaxRetries,
   });
 }

--- a/packages/chrono-core/src/processors/create-processor.ts
+++ b/packages/chrono-core/src/processors/create-processor.ts
@@ -5,7 +5,7 @@ import type { Processor } from './processor';
 import { SimpleProcessor } from './simple-processor';
 
 export type ProcessorConfiguration = {
-  maxConcurrency: number;
+  maxConcurrency?: number;
   claimIntervalMs?: number;
   idleIntervalMs?: number;
   taskHandlerTimeoutMs?: number;

--- a/packages/chrono-core/src/processors/create-processor.ts
+++ b/packages/chrono-core/src/processors/create-processor.ts
@@ -6,6 +6,10 @@ import { SimpleProcessor } from './simple-processor';
 
 export type ProcessorConfiguration = {
   maxConcurrency: number;
+  claimIntervalMs?: number;
+  idleIntervalMs?: number;
+  taskHandlerTimeoutMs?: number;
+  taskHandlerMaxRetries?: number;
 };
 
 export type CreateProcessorInput<
@@ -33,5 +37,9 @@ export function createProcessor<
     handler: input.handler,
     maxConcurrency: input.configuration.maxConcurrency,
     backoffStrategy,
+    claimIntervalMs: input.configuration.claimIntervalMs,
+    idleIntervalMs: input.configuration.idleIntervalMs,
+    taskHandlerTimeoutMs: input.configuration.taskHandlerTimeoutMs,
+    taskHandlerMaxRetries: input.configuration.taskHandlerMaxRetries,
   });
 }

--- a/packages/chrono-core/src/processors/processor.ts
+++ b/packages/chrono-core/src/processors/processor.ts
@@ -3,4 +3,5 @@ import type { EventEmitter } from 'node:stream';
 export interface Processor extends EventEmitter {
   start(): Promise<void>;
   stop(): Promise<void>;
+  getTaskHandlerTimeoutMs(): number;
 }

--- a/packages/chrono-core/src/processors/processor.ts
+++ b/packages/chrono-core/src/processors/processor.ts
@@ -3,5 +3,4 @@ import type { EventEmitter } from 'node:stream';
 export interface Processor extends EventEmitter {
   start(): Promise<void>;
   stop(): Promise<void>;
-  getTaskHandlerTimeoutMs(): number;
 }

--- a/packages/chrono-core/src/processors/simple-processor.ts
+++ b/packages/chrono-core/src/processors/simple-processor.ts
@@ -9,7 +9,7 @@ import type { Processor } from './processor';
 
 const DEFAULT_CLAIM_INTERVAL_MS = 50;
 const DEFAULT_IDLE_INTERVAL_MS = 5_000;
-const DEFAULT_TASK_HANDLER_TIMEOUT_MS = 60_000;
+const DEFAULT_TASK_HANDLER_TIMEOUT_MS = 5_000;
 const DEFAULT_TASK_HANDLER_MAX_RETRIES = 10;
 
 type SimpleProcessorConfig<
@@ -70,14 +70,14 @@ export class SimpleProcessor<
   }
 
   /**
-   * Validates the task handler timeout against the claim interval.
+   * Validates the task handler timeout against the claim stale timeout.
    *
-   * @throws {Error} If the task handler timeout is less than or equal to the claim interval.
+   * @throws {Error} If the task handler timeout is greater than or equal to the claim stale timeout.
    */
   private validateTaskHandlerTimeout(): void {
-    if (this.datastore.getClaimStaleTimeoutMs() <= this.claimIntervalMs) {
+    if (this.taskHandlerTimeoutMs >= this.datastore.getClaimStaleTimeoutMs()) {
       throw new Error(
-        `Claim stale timeout (${this.datastore.getClaimStaleTimeoutMs()}) must be greater than claim interval (${this.claimIntervalMs}ms).`,
+        `Task handler timeout (${this.taskHandlerTimeoutMs}ms) must be less than the claim stale timeout (${this.datastore.getClaimStaleTimeoutMs()}ms).`,
       );
     }
   }

--- a/packages/chrono-core/src/processors/simple-processor.ts
+++ b/packages/chrono-core/src/processors/simple-processor.ts
@@ -65,6 +65,21 @@ export class SimpleProcessor<
     this.idleIntervalMs = config.idleIntervalMs || DEFAULT_IDLE_INTERVAL_MS;
     this.taskHandlerTimeoutMs = config.taskHandlerTimeoutMs || DEFAULT_TASK_HANDLER_TIMEOUT_MS;
     this.taskHandlerMaxRetries = config.taskHandlerMaxRetries || DEFAULT_TASK_HANDLER_MAX_RETRIES;
+
+    this.validateTaskHandlerTimeout();
+  }
+
+  /**
+   * Validates the task handler timeout against the claim interval.
+   *
+   * @throws {Error} If the task handler timeout is less than or equal to the claim interval.
+   */
+  private validateTaskHandlerTimeout(): void {
+    if (this.datastore.getClaimStaleTimeoutMs() <= this.claimIntervalMs) {
+      throw new Error(
+        `Claim stale timeout (${this.datastore.getClaimStaleTimeoutMs()}) must be greater than claim interval (${this.claimIntervalMs}ms).`,
+      );
+    }
   }
 
   /**

--- a/packages/chrono-core/src/processors/simple-processor.ts
+++ b/packages/chrono-core/src/processors/simple-processor.ts
@@ -65,21 +65,10 @@ export class SimpleProcessor<
     this.idleIntervalMs = config.idleIntervalMs || DEFAULT_IDLE_INTERVAL_MS;
     this.taskHandlerTimeoutMs = config.taskHandlerTimeoutMs || DEFAULT_TASK_HANDLER_TIMEOUT_MS;
     this.taskHandlerMaxRetries = config.taskHandlerMaxRetries || DEFAULT_TASK_HANDLER_MAX_RETRIES;
-
-    this.validateTaskHandlerTimeout();
   }
 
-  /**
-   * Validates the task handler timeout against the claim stale timeout.
-   *
-   * @throws {Error} If the task handler timeout is greater than or equal to the claim stale timeout.
-   */
-  private validateTaskHandlerTimeout(): void {
-    if (this.taskHandlerTimeoutMs >= this.datastore.getClaimStaleTimeoutMs()) {
-      throw new Error(
-        `Task handler timeout (${this.taskHandlerTimeoutMs}ms) must be less than the claim stale timeout (${this.datastore.getClaimStaleTimeoutMs()}ms).`,
-      );
-    }
+  getTaskHandlerTimeoutMs(): number {
+    return this.taskHandlerTimeoutMs;
   }
 
   /**

--- a/packages/chrono-core/src/processors/simple-processor.ts
+++ b/packages/chrono-core/src/processors/simple-processor.ts
@@ -7,6 +7,11 @@ import type { Datastore, Task } from '../datastore';
 import { promiseWithTimeout } from '../utils/promise-utils';
 import type { Processor } from './processor';
 
+const DEFAULT_CLAIM_INTERVAL_MS = 50;
+const DEFAULT_IDLE_INTERVAL_MS = 5_000;
+const DEFAULT_TASK_HANDLER_TIMEOUT_MS = 60_000;
+const DEFAULT_TASK_HANDLER_MAX_RETRIES = 10;
+
 type SimpleProcessorConfig<
   TaskKind extends keyof TaskMapping,
   TaskMapping extends TaskMappingBase,
@@ -55,10 +60,11 @@ export class SimpleProcessor<
     this.maxConcurrency = config.maxConcurrency;
     this.taskKind = config.kind;
     this.backOffStrategy = config.backoffStrategy;
-    this.claimIntervalMs = config.claimIntervalMs || 50;
-    this.idleIntervalMs = config.idleIntervalMs || 5_000;
-    this.taskHandlerTimeoutMs = config.taskHandlerTimeoutMs || 60_000;
-    this.taskHandlerMaxRetries = config.taskHandlerMaxRetries || 10;
+
+    this.claimIntervalMs = config.claimIntervalMs || DEFAULT_CLAIM_INTERVAL_MS;
+    this.idleIntervalMs = config.idleIntervalMs || DEFAULT_IDLE_INTERVAL_MS;
+    this.taskHandlerTimeoutMs = config.taskHandlerTimeoutMs || DEFAULT_TASK_HANDLER_TIMEOUT_MS;
+    this.taskHandlerMaxRetries = config.taskHandlerMaxRetries || DEFAULT_TASK_HANDLER_MAX_RETRIES;
   }
 
   /**

--- a/packages/chrono-core/src/processors/simple-processor.ts
+++ b/packages/chrono-core/src/processors/simple-processor.ts
@@ -7,6 +7,7 @@ import type { Datastore, Task } from '../datastore';
 import { promiseWithTimeout } from '../utils/promise-utils';
 import type { Processor } from './processor';
 
+const DEFAULT_MAX_CONCURRENCY = 1;
 const DEFAULT_CLAIM_INTERVAL_MS = 50;
 const DEFAULT_IDLE_INTERVAL_MS = 5_000;
 const DEFAULT_TASK_HANDLER_TIMEOUT_MS = 5_000;
@@ -20,7 +21,7 @@ type SimpleProcessorConfig<
   datastore: Datastore<TaskMapping, DatastoreOptions>;
   kind: TaskKind;
   handler: (task: Task<TaskKind, TaskMapping[TaskKind]>) => Promise<void>;
-  maxConcurrency: number;
+  maxConcurrency?: number;
   backoffStrategy: BackoffStrategy;
   claimIntervalMs?: number;
   idleIntervalMs?: number;
@@ -57,10 +58,10 @@ export class SimpleProcessor<
 
     this.datastore = config.datastore;
     this.handler = config.handler;
-    this.maxConcurrency = config.maxConcurrency;
     this.taskKind = config.kind;
     this.backOffStrategy = config.backoffStrategy;
 
+    this.maxConcurrency = config.maxConcurrency || DEFAULT_MAX_CONCURRENCY;
     this.claimIntervalMs = config.claimIntervalMs || DEFAULT_CLAIM_INTERVAL_MS;
     this.idleIntervalMs = config.idleIntervalMs || DEFAULT_IDLE_INTERVAL_MS;
     this.taskHandlerTimeoutMs = config.taskHandlerTimeoutMs || DEFAULT_TASK_HANDLER_TIMEOUT_MS;

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -202,20 +202,20 @@ describe('Chrono', () => {
 
     test('throws an error if the task handler timeout is equal to task claim stale timeout', () => {
       const mockHandler = vitest.fn();
-      const mockClaimStaleTimeoutMs = 1000;
-
-      mockDatastore.getClaimStaleTimeoutMs.mockReturnValue(mockClaimStaleTimeoutMs);
+      const mockClaimStaleTimeoutMs = 5_000;
+      const mockTaskHandlerTimeoutMs = mockClaimStaleTimeoutMs;
 
       expect(() =>
         chronoInstance.registerTaskHandler({
           kind: 'send-test-task',
           handler: mockHandler,
           processorConfiguration: {
-            taskHandlerTimeoutMs: mockClaimStaleTimeoutMs,
+            taskHandlerTimeoutMs: mockTaskHandlerTimeoutMs,
+            claimStaleTimeoutMs: mockClaimStaleTimeoutMs,
           },
         }),
       ).toThrow(
-        `Task handler timeout (${mockClaimStaleTimeoutMs}ms) must be less than the claim stale timeout (${mockClaimStaleTimeoutMs}ms)`,
+        `Task handler timeout (${mockTaskHandlerTimeoutMs}ms) must be less than the claim stale timeout (${mockClaimStaleTimeoutMs}ms)`,
       );
     });
 
@@ -224,14 +224,13 @@ describe('Chrono', () => {
       const mockClaimStaleTimeoutMs = 1000;
       const mockTaskHandlerTimeoutMs = mockClaimStaleTimeoutMs + 1;
 
-      mockDatastore.getClaimStaleTimeoutMs.mockReturnValue(mockClaimStaleTimeoutMs);
-
       expect(() =>
         chronoInstance.registerTaskHandler({
           kind: 'send-test-task',
           handler: mockHandler,
           processorConfiguration: {
             taskHandlerTimeoutMs: mockTaskHandlerTimeoutMs,
+            claimStaleTimeoutMs: mockClaimStaleTimeoutMs,
           },
         }),
       ).toThrow(

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -1,9 +1,10 @@
 import { faker } from '@faker-js/faker';
-import { describe, expect, test, vitest } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vitest } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { Chrono } from '../../src/chrono';
 import { type Datastore, type Task, TaskStatus } from '../../src/datastore';
+import { SimpleProcessor } from '../../src/processors/simple-processor';
 
 describe('Chrono', () => {
   type TaskData = { someField: number };
@@ -26,6 +27,10 @@ describe('Chrono', () => {
     scheduledAt: faker.date.future(),
     retryCount: 0,
   };
+
+  afterEach(() => {
+    vitest.resetAllMocks();
+  });
 
   describe('start', () => {
     test('emits ready event when chrono is instantiated successfully', async () => {
@@ -169,6 +174,76 @@ describe('Chrono', () => {
         taskId: mockTask.id,
         timestamp: expect.any(Date),
       });
+    });
+  });
+
+  describe('registerTaskHandler', () => {
+    let chronoInstance: Chrono<TaskMapping, DatastoreOptions>;
+
+    beforeEach(() => {
+      chronoInstance = new Chrono<TaskMapping, DatastoreOptions>(mockDatastore);
+    });
+
+    test('throws an error if the handler for the task kind already exists', () => {
+      const mockHandler = vitest.fn();
+
+      chronoInstance.registerTaskHandler({
+        kind: 'send-test-task',
+        handler: mockHandler,
+      });
+
+      expect(() =>
+        chronoInstance.registerTaskHandler({
+          kind: 'send-test-task',
+          handler: mockHandler,
+        }),
+      ).toThrow('Handler for task kind already exists');
+    });
+
+    test('throws an error if the task handler timeout is equal to task claim stale timeout', () => {
+      const mockHandler = vitest.fn();
+      const mockClaimStaleTimeoutMs = 1000;
+
+      mockDatastore.getClaimStaleTimeoutMs.mockReturnValue(mockClaimStaleTimeoutMs);
+
+      expect(() =>
+        chronoInstance.registerTaskHandler({
+          kind: 'send-test-task',
+          handler: mockHandler,
+          taskHandlerTimeoutMs: mockClaimStaleTimeoutMs,
+        }),
+      ).toThrow(
+        `Task handler timeout (${mockClaimStaleTimeoutMs}ms) must be less than the claim stale timeout (${mockClaimStaleTimeoutMs}ms)`,
+      );
+    });
+
+    test('throws an error if the task handler timeout is greter than task claim stale timeout', () => {
+      const mockHandler = vitest.fn();
+      const mockClaimStaleTimeoutMs = 1000;
+      const mockTaskHandlerTimeoutMs = mockClaimStaleTimeoutMs + 1;
+
+      mockDatastore.getClaimStaleTimeoutMs.mockReturnValue(mockClaimStaleTimeoutMs);
+
+      expect(() =>
+        chronoInstance.registerTaskHandler({
+          kind: 'send-test-task',
+          handler: mockHandler,
+          taskHandlerTimeoutMs: mockTaskHandlerTimeoutMs,
+        }),
+      ).toThrow(
+        `Task handler timeout (${mockTaskHandlerTimeoutMs}ms) must be less than the claim stale timeout (${mockClaimStaleTimeoutMs}ms)`,
+      );
+    });
+
+    test('registers a task handler successfully', () => {
+      const mockHandler = vitest.fn();
+
+      const result = chronoInstance.registerTaskHandler({
+        kind: 'send-test-task',
+        handler: mockHandler,
+      });
+
+      expect(result).toBeInstanceOf(SimpleProcessor);
     });
   });
 });

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -210,7 +210,9 @@ describe('Chrono', () => {
         chronoInstance.registerTaskHandler({
           kind: 'send-test-task',
           handler: mockHandler,
-          taskHandlerTimeoutMs: mockClaimStaleTimeoutMs,
+          processorConfiguration: {
+            taskHandlerTimeoutMs: mockClaimStaleTimeoutMs,
+          },
         }),
       ).toThrow(
         `Task handler timeout (${mockClaimStaleTimeoutMs}ms) must be less than the claim stale timeout (${mockClaimStaleTimeoutMs}ms)`,
@@ -228,7 +230,9 @@ describe('Chrono', () => {
         chronoInstance.registerTaskHandler({
           kind: 'send-test-task',
           handler: mockHandler,
-          taskHandlerTimeoutMs: mockTaskHandlerTimeoutMs,
+          processorConfiguration: {
+            taskHandlerTimeoutMs: mockTaskHandlerTimeoutMs,
+          },
         }),
       ).toThrow(
         `Task handler timeout (${mockTaskHandlerTimeoutMs}ms) must be less than the claim stale timeout (${mockClaimStaleTimeoutMs}ms)`,

--- a/packages/chrono-memory-datastore/src/chrono-memory-datastore.ts
+++ b/packages/chrono-memory-datastore/src/chrono-memory-datastore.ts
@@ -31,7 +31,7 @@ export class ChronoMemoryDatastore<TaskMapping extends TaskMappingBase, MemoryDa
    *
    * @returns The timeout in milliseconds.
    */
-  getClaimStaleTimeout(): number {
+  getClaimStaleTimeoutMs(): number {
     return this.config.claimStaleTimeout;
   }
 

--- a/packages/chrono-memory-datastore/src/chrono-memory-datastore.ts
+++ b/packages/chrono-memory-datastore/src/chrono-memory-datastore.ts
@@ -8,32 +8,13 @@ import {
 } from '@neofinancial/chrono-core';
 import type { DeleteInput, DeleteOptions } from '@neofinancial/chrono-core/build/datastore';
 
-const DEFAULT_CLAIM_STALE_TIMEOUT = 10_000; // 10 seconds
-
-type ChronoMemoryDatastoreConfig = {
-  claimStaleTimeout: number;
-};
-
 export class ChronoMemoryDatastore<TaskMapping extends TaskMappingBase, MemoryDatastoreOptions>
   implements Datastore<TaskMapping, MemoryDatastoreOptions>
 {
   private store: Map<string, Task<keyof TaskMapping, TaskMapping[keyof TaskMapping]>>;
-  private config: ChronoMemoryDatastoreConfig;
 
-  constructor(config?: Partial<ChronoMemoryDatastoreConfig>) {
+  constructor() {
     this.store = new Map();
-    this.config = {
-      claimStaleTimeout: config?.claimStaleTimeout || DEFAULT_CLAIM_STALE_TIMEOUT,
-    };
-  }
-
-  /**
-   * Returns the timeout for claimed tasks.
-   *
-   * @returns The timeout in milliseconds.
-   */
-  getClaimStaleTimeoutMs(): number {
-    return this.config.claimStaleTimeout;
   }
 
   /**
@@ -134,7 +115,7 @@ export class ChronoMemoryDatastore<TaskMapping extends TaskMappingBase, MemoryDa
         t.kind === input.kind &&
         t.status === TaskStatus.CLAIMED &&
         t.claimedAt &&
-        t.claimedAt <= new Date(now.getTime() - this.config.claimStaleTimeout)
+        t.claimedAt <= new Date(now.getTime() - input.claimStaleTimeoutMs)
       ) {
         return t;
       }

--- a/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
+++ b/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
@@ -47,7 +47,12 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     };
   }
 
-  getClaimStaleTimeout(): number {
+  /**
+   * Returns the timeout for claimed tasks.
+   *
+   * @returns The timeout in milliseconds.
+   */
+  getClaimStaleTimeoutMs(): number {
     return this.config.claimStaleTimeout;
   }
 

--- a/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
+++ b/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
@@ -47,6 +47,10 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     };
   }
 
+  getClaimStaleTimeout(): number {
+    return this.config.claimStaleTimeout;
+  }
+
   static async create<TaskMapping extends TaskMappingBase>(
     database: Db,
     config?: Partial<ChronoMongoDatastoreConfig>,

--- a/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
+++ b/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
@@ -18,12 +18,10 @@ import {
 import { IndexNames, ensureIndexes } from './mongo-indexes';
 
 const DEFAULT_COLLECTION_NAME = 'chrono-tasks';
-const DEFAULT_CLAIM_STALE_TIMEOUT = 10_000; // 10 seconds
 
 export type ChronoMongoDatastoreConfig = {
   completedDocumentTTL?: number;
   collectionName: string;
-  claimStaleTimeout: number;
 };
 
 export type MongoDatastoreOptions = {
@@ -42,18 +40,8 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     this.database = database;
     this.config = {
       completedDocumentTTL: config?.completedDocumentTTL,
-      claimStaleTimeout: config?.claimStaleTimeout || DEFAULT_CLAIM_STALE_TIMEOUT,
       collectionName: config?.collectionName || DEFAULT_COLLECTION_NAME,
     };
-  }
-
-  /**
-   * Returns the timeout for claimed tasks.
-   *
-   * @returns The timeout in milliseconds.
-   */
-  getClaimStaleTimeoutMs(): number {
-    return this.config.claimStaleTimeout;
   }
 
   static async create<TaskMapping extends TaskMappingBase>(
@@ -163,7 +151,7 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
           {
             status: TaskStatus.CLAIMED,
             claimedAt: {
-              $lte: new Date(now.getTime() - this.config.claimStaleTimeout),
+              $lte: new Date(now.getTime() - input.claimStaleTimeoutMs),
             },
           },
         ],

--- a/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
+++ b/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
@@ -145,7 +145,9 @@ describe('ChronoMongoDatastore', () => {
       });
 
       const fakeTimer = vitest.useFakeTimers();
-      fakeTimer.setSystemTime(new Date((claimedTask?.claimedAt?.getTime() as number) + 10_000 + 1));
+      fakeTimer.setSystemTime(
+        new Date((claimedTask?.claimedAt?.getTime() as number) + TEST_CLAIM_STALE_TIMEOUT_MS + 1),
+      );
 
       const claimedTaskAgainAgain = await dataStore.claim({
         kind: input.kind,
@@ -393,7 +395,7 @@ describe('ChronoMongoDatastore', () => {
         when,
       });
 
-      await dataStore.claim({ kind: task.kind, claimStaleTimeoutMs: 10_000 });
+      await dataStore.claim({ kind: task.kind, claimStaleTimeoutMs: TEST_CLAIM_STALE_TIMEOUT_MS });
 
       await expect(dataStore.delete(task.id)).rejects.toThrow(
         `Task with id ${task.id} can not be deleted as it may not exist or it's not in PENDING status.`,
@@ -410,7 +412,7 @@ describe('ChronoMongoDatastore', () => {
         when,
       });
 
-      await dataStore.claim({ kind: task.kind, claimStaleTimeoutMs: 10_000 });
+      await dataStore.claim({ kind: task.kind, claimStaleTimeoutMs: TEST_CLAIM_STALE_TIMEOUT_MS });
 
       await dataStore.delete(task.id, { force: true });
 


### PR DESCRIPTION
### Description
- Make the Processor configurable by exposing the configs when calling `chrono.registerTaskHandler()` method.
- Added validation on task handler timeout to check if it's less than the task claim stale timeout.
- Update `MemoryDatastore` to handle `claimStaleTimeout` as well.