### PR TITLE
Rename to unclaim to retryAt and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Chrono
 
-This project is pre-alpha, and not ready for production use. 
+⚠️ This project is pre-alpha, and not ready for production use. ⚠️
+
 A TypeScript task scheduling and processing system for reliable background job processing.
 
 Chrono is a monorepo containing `@neofinancial/chrono` built in datastore implementations.

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ const chrono = new Chrono<TaskMapping, { collection: string }>(datastore);
 - `processloop.error` - Emits this event when an error occurs in the process loop (the process of claiming a task and processing it by calling the given handler).
 
 **Task related events**
-- `task.claimed` - Emits this event when a task is claimed.
-- `task.completed` - Emits this event when a task is successfully processed.
-- `task.complete.failed` -  Emits this event when the task fails to mark as completed.
-- `task.unclaimed` - Emits this event when the processor receives an error from the given task handler and the task will be retried.
-- `task.failed` - Emits this event when the processor receives an error from the given task handler and the max retries is reached.
+- `task:claimed` - Emits this event when a task is claimed.
+- `task:completed` - Emits this event when a task is successfully processed.
+- `task:completion:failed` -  Emits this event when the task fails to mark as completed.
+- `task:retry:requested` - Emits this event when the processor receives an error from the given task handler and the task will be retried.
+- `task:failed` - Emits this event when the processor receives an error from the given task handler and the max retries is reached.

--- a/packages/chrono-core/src/datastore.ts
+++ b/packages/chrono-core/src/datastore.ts
@@ -75,7 +75,7 @@ export interface Datastore<TaskMapping extends TaskMappingBase, DatastoreOptions
   claim<TaskKind extends Extract<keyof TaskMapping, string>>(
     input: ClaimTaskInput<TaskKind>,
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]> | undefined>;
-  unclaim<TaskKind extends keyof TaskMapping>(
+  retryAt<TaskKind extends keyof TaskMapping>(
     taskId: string,
     nextScheduledAt: Date,
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]>>;

--- a/packages/chrono-core/src/processors/processor.ts
+++ b/packages/chrono-core/src/processors/processor.ts
@@ -5,7 +5,7 @@ export type ProcessorEvents<TaskKind extends keyof TaskMapping, TaskMapping exte
   'task:claimed': [{ task: Task<TaskKind, TaskMapping[TaskKind]>; timestamp: Date }];
   'task:completed': [{ task: Task<TaskKind, TaskMapping[TaskKind]>; timestamp: Date }];
   'task:failed': [{ task: Task<TaskKind, TaskMapping[TaskKind]>; error: Error; timestamp: Date }];
-  'task:unclaimed': [{ task: Task<TaskKind, TaskMapping[TaskKind]>; error: Error; timestamp: Date }];
+  'task:retry:requested': [{ task: Task<TaskKind, TaskMapping[TaskKind]>; error: Error; timestamp: Date }];
   'task:completion:failed': [{ task: Task<TaskKind, TaskMapping[TaskKind]>; error: Error; timestamp: Date }];
   'processloop:error': [{ error: Error; timestamp: Date }];
 };

--- a/packages/chrono-core/src/processors/simple-processor.ts
+++ b/packages/chrono-core/src/processors/simple-processor.ts
@@ -207,8 +207,8 @@ export class SimpleProcessor<
     const delay = this.backOffStrategy({ retryAttempt: task.retryCount });
     const nextScheduledAt = new Date(Date.now() + delay);
 
-    await this.datastore.unclaim(task.id, nextScheduledAt);
-    this.emit('task:unclaimed', {
+    await this.datastore.retryAt(task.id, nextScheduledAt);
+    this.emit('task:retry:requested', {
       task,
       error,
       timestamp: new Date(),

--- a/packages/chrono-memory-datastore/src/chrono-memory-datastore.ts
+++ b/packages/chrono-memory-datastore/src/chrono-memory-datastore.ts
@@ -130,12 +130,12 @@ export class ChronoMemoryDatastore<TaskMapping extends TaskMappingBase, MemoryDa
   }
 
   /**
-   * Unclaims a task and returns it. Primarily used for retrying tasks.
+   * Schedules a task to be retried and returns it.
    *
-   * @param taskId The ID of the task to unclaim.
-   * @returns The unclaimed task.
+   * @param taskId The ID of the task to retry.
+   * @returns The task to retry.
    */
-  async unclaim<TaskKind extends keyof TaskMapping>(
+  async retryAt<TaskKind extends keyof TaskMapping>(
     taskId: string,
     nextScheduledAt: Date,
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]>> {

--- a/packages/chrono-memory-datastore/test/unit/chrono-memory-datastore.test.ts
+++ b/packages/chrono-memory-datastore/test/unit/chrono-memory-datastore.test.ts
@@ -157,7 +157,7 @@ describe('ChronoMemoryDatastore', () => {
         datastoreOptions: {},
       });
 
-      await memoryDatastore.claim({ kind: task.kind });
+      await memoryDatastore.claim({ kind: task.kind, claimStaleTimeoutMs: 1000 });
 
       await expect(memoryDatastore.delete(task.id)).rejects.toThrow(
         `Task with id ${task.id} can not be deleted as it may not exist or it's not in PENDING status.`,
@@ -176,11 +176,11 @@ describe('ChronoMemoryDatastore', () => {
         datastoreOptions: {},
       });
 
-      await memoryDatastore.claim({ kind: task.kind });
+      await memoryDatastore.claim({ kind: task.kind, claimStaleTimeoutMs: 1000 });
 
       await memoryDatastore.delete(task.id, { force: true });
 
-      await expect(memoryDatastore.unclaim(task.id, new Date())).rejects.toThrow(`Task with id ${task.id} not found`);
+      await expect(memoryDatastore.retryAt(task.id, new Date())).rejects.toThrow(`Task with id ${task.id} not found`);
     });
 
     test('noops when force deleting a task that does not exist', async () => {

--- a/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
+++ b/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
@@ -167,7 +167,7 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     return task ? this.toObject(task) : undefined;
   }
 
-  async unclaim<TaskKind extends keyof TaskMapping>(
+  async retryAt<TaskKind extends keyof TaskMapping>(
     taskId: string,
     nextScheduledAt: Date,
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]>> {

--- a/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
+++ b/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
@@ -282,8 +282,8 @@ describe('ChronoMongoDatastore', () => {
     });
   });
 
-  describe('unclaim', () => {
-    test('should unclaim task', async () => {
+  describe('retryAt', () => {
+    test('should retry task', async () => {
       const firstScheduleDate = faker.date.past();
       const secondScheduleDate = faker.date.past();
 
@@ -303,7 +303,7 @@ describe('ChronoMongoDatastore', () => {
         }),
       );
 
-      const unclaimedTask = await dataStore.unclaim(task.id, secondScheduleDate);
+      const taskToRetry = await dataStore.retryAt(task.id, secondScheduleDate);
       const taskDocument = await collection.findOne({
         _id: new ObjectId(task.id),
       });
@@ -317,7 +317,7 @@ describe('ChronoMongoDatastore', () => {
           retryCount: 1,
         }),
       );
-      expect(unclaimedTask).toEqual(
+      expect(taskToRetry).toEqual(
         expect.objectContaining({
           id: task.id,
           kind: task.kind,


### PR DESCRIPTION
- Highlights that this is not ready for production use in the readme.
- Renames the unclaim method to retryAt, which was picked over simply retry since it can be scheduled in the future.