### PR TITLE
listen to correct exit channel event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,15 +152,13 @@ const chrono = new Chrono<TaskMapping, { collection: string }>(datastore);
 ### Chrono instance events
 
 - `ready` - Emits this event when all processors are started as a result of calling `chrono.start()` method.
-- `stopped` - Emits this event when all processors are successfully stopped as a result of calling `chrono.stop()` method.
-- `stop.failed` - Emits this event if any processor fails to stop within the exit timeout as a result of calling `chrono.stop()` method.
 - `close` - Emits this event after stopping all processors regardless successful or not as a result of calling `chrono.stop()` method.
+- `stop:failed` - Emits this event if any processor fails to stop within the exit timeout as a result of calling `chrono.stop()` method.
 
 ### Processor instance events
 
 **Process loop related events**
-
-- `processloop.error` - Emits this event when an error occurs in the process loop (the process of claiming a task and processing it by calling the given handler).
+- `processloop:error` - Emits this event when an error occurs in the process loop (the process of claiming a task and processing it by calling the given handler).
 
 **Task related events**
 - `task:claimed` - Emits this event when a task is claimed.

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -58,10 +58,8 @@ export class Chrono<TaskMapping extends TaskMappingBase, DatastoreOptions> exten
 
     try {
       await promiseWithTimeout(Promise.all(stopPromises), this.exitTimeoutMs);
-
-      this.emit('stopped', { timestamp: new Date() });
     } catch (error) {
-      this.emit('stop.failed', { error, timestamp: new Date() });
+      this.emit('stop:failed', { error, timestamp: new Date() });
     } finally {
       this.emit('close', { timestamp: new Date() });
     }

--- a/packages/chrono-core/src/processors/simple-processor.ts
+++ b/packages/chrono-core/src/processors/simple-processor.ts
@@ -113,7 +113,7 @@ export class SimpleProcessor<
    */
   async stop(): Promise<void> {
     const exitPromises = this.exitChannels.map(
-      (channel) => new Promise((resolve) => channel.once('processloop.exit', resolve)),
+      (channel) => new Promise((resolve) => channel.once('processloop:exit', resolve)),
     );
 
     this.stopRequested = true;

--- a/packages/chrono-core/test/unit/chrono.test.ts
+++ b/packages/chrono-core/test/unit/chrono.test.ts
@@ -46,16 +46,13 @@ describe('Chrono', () => {
   });
 
   describe('stop', () => {
-    test('emits stopped and close event when chrono is stopped successfully', async () => {
+    test('emits close event when chrono is stopped successfully', async () => {
       const emitSpy = vitest.spyOn(chrono, 'emit');
 
       await chrono.stop();
 
-      expect(emitSpy).toHaveBeenCalledTimes(2);
-      expect(emitSpy).toHaveBeenNthCalledWith(1, 'stopped', {
-        timestamp: expect.any(Date),
-      });
-      expect(emitSpy).toHaveBeenNthCalledWith(2, 'close', {
+      expect(emitSpy).toHaveBeenCalledOnce();
+      expect(emitSpy).toHaveBeenCalledWith('close', {
         timestamp: expect.any(Date),
       });
     });


### PR DESCRIPTION
### Description
- Updated exit channel event listener to listen to the updated [exit event name](https://github.com/neofinancial/chrono/pull/49/files#diff-af1b023d77f037b46fba83f124cac76db4e2c73e4f12101aa991b3a4b8b6c369R116) - `processloop:exit`.

_Others:_ [Removed unnecessary chrono](https://github.com/neofinancial/chrono/pull/49/files#diff-86fe1efc47faafa7a4350ecdcb9f23cedbffafd9232c3a600b9876970e69f279R60-R62) `stopped` event as it's just a redundant to `close` event.