### PR TITLE
Allow creation of chrono-mongo-datastore instance without db connection

### DIFF
--- a/packages/chrono-core/package.json
+++ b/packages/chrono-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neofinancial/chrono",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Core package for Chrono task scheduling system",
   "private": false,
   "publishConfig": {

--- a/packages/chrono-mongo-datastore/package.json
+++ b/packages/chrono-mongo-datastore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neofinancial/chrono-mongo-datastore",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "MongoDB datastore implementation for Chrono task scheduling system",
   "private": false,
   "publishConfig": {

--- a/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
+++ b/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
@@ -63,16 +63,16 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
    *
    * @param database - The database to set.
    */
-  async setDatabase(database: Db) {
+  async initialize(database: Db) {
     if (this.database) {
       throw new Error('Database connection already set');
     }
 
-    this.database = database;
-
     await ensureIndexes(database.collection(this.config.collectionName), {
       expireAfterSeconds: this.config.completedDocumentTTLSeconds,
     });
+
+    this.database = database;
 
     const resolvers = this.databaseResolvers.splice(0);
     for (const resolve of resolvers) {

--- a/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
+++ b/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
@@ -59,11 +59,15 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
   }
 
   /**
-   * Sets the database for the datastore. Ensures that the indexes are created and resolves any pending promises waiting for the database.
+   * Sets the database connection for the datastore. Ensures that the indexes are created and resolves any pending promises waiting for the database.
    *
    * @param database - The database to set.
    */
   async setDatabase(database: Db) {
+    if (this.database) {
+      throw new Error('Database connection already set');
+    }
+
     this.database = database;
 
     await ensureIndexes(database.collection(this.config.collectionName), {

--- a/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
+++ b/packages/chrono-mongo-datastore/src/chrono-mongo-datastore.ts
@@ -48,27 +48,47 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
   implements Datastore<TaskMapping, MongoDatastoreOptions>
 {
   private config: ChronoMongoDatastoreConfig;
-  private database: Db;
+  private database: Db | undefined;
+  private databaseResolvers: Array<(database: Db) => void> = [];
 
-  private constructor(database: Db, config?: Partial<ChronoMongoDatastoreConfig>) {
-    this.database = database;
+  constructor(config?: Partial<ChronoMongoDatastoreConfig>) {
     this.config = {
       completedDocumentTTLSeconds: config?.completedDocumentTTLSeconds,
       collectionName: config?.collectionName || DEFAULT_COLLECTION_NAME,
     };
   }
 
-  static async create<TaskMapping extends TaskMappingBase>(
-    database: Db,
-    config?: Partial<ChronoMongoDatastoreConfig>,
-  ): Promise<ChronoMongoDatastore<TaskMapping>> {
-    const datastore = new ChronoMongoDatastore<TaskMapping>(database, config);
+  /**
+   * Sets the database for the datastore. Ensures that the indexes are created and resolves any pending promises waiting for the database.
+   *
+   * @param database - The database to set.
+   */
+  async setDatabase(database: Db) {
+    this.database = database;
 
-    await ensureIndexes(database.collection(datastore.config.collectionName), {
-      expireAfterSeconds: datastore.config.completedDocumentTTLSeconds,
+    await ensureIndexes(database.collection(this.config.collectionName), {
+      expireAfterSeconds: this.config.completedDocumentTTLSeconds,
     });
 
-    return datastore;
+    const resolvers = this.databaseResolvers.splice(0);
+    for (const resolve of resolvers) {
+      resolve(database);
+    }
+  }
+
+  /**
+   * Asyncronously gets the database connection for the datastore. If the database is not set, it will return a promise that resolves when the database is set.
+   *
+   * @returns The database connection.
+   */
+  public async getDatabase(): Promise<Db> {
+    if (this.database) {
+      return this.database;
+    }
+
+    return new Promise<Db>((resolve) => {
+      this.databaseResolvers.push(resolve);
+    });
   }
 
   async schedule<TaskKind extends keyof TaskMapping>(
@@ -86,7 +106,8 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     };
 
     try {
-      const results = await this.database.collection(this.config.collectionName).insertOne(createInput, {
+      const database = await this.getDatabase();
+      const results = await database.collection(this.config.collectionName).insertOne(createInput, {
         ...(input?.datastoreOptions?.session ? { session: input.datastoreOptions.session } : undefined),
         ignoreUndefined: true,
       });
@@ -101,7 +122,8 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
         'code' in error &&
         (error.code === 11000 || error.code === 11001)
       ) {
-        const existingTask = await this.collection<TaskKind>().findOne(
+        const collection = await this.collection<TaskKind>();
+        const existingTask = await collection.findOne(
           {
             idempotencyKey: input.idempotencyKey,
           },
@@ -131,7 +153,8 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]> | undefined> {
     const filter =
       typeof key === 'string' ? { _id: new ObjectId(key) } : { kind: key.kind, idempotencyKey: key.idempotencyKey };
-    const task = await this.collection<TaskKind>().findOneAndDelete({
+    const collection = await this.collection<TaskKind>();
+    const task = await collection.findOneAndDelete({
       ...filter,
       ...(options?.force ? {} : { status: TaskStatus.PENDING }),
     });
@@ -156,7 +179,8 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     input: ClaimTaskInput<TaskKind>,
   ): Promise<Task<TaskKind, TaskMapping[TaskKind]> | undefined> {
     const now = new Date();
-    const task = await this.collection<TaskKind>().findOneAndUpdate(
+    const collection = await this.collection<TaskKind>();
+    const task = await collection.findOneAndUpdate(
       {
         kind: input.kind,
         scheduledAt: { $lte: now },
@@ -229,17 +253,22 @@ export class ChronoMongoDatastore<TaskMapping extends TaskMappingBase>
     taskId: string,
     update: UpdateFilter<TaskDocument<TaskKind, TaskMapping[TaskKind]>>,
   ): Promise<TaskDocument<TaskKind, TaskMapping[TaskKind]>> {
-    const document = await this.collection<TaskKind>().findOneAndUpdate({ _id: new ObjectId(taskId) }, update, {
+    const collection = await this.collection<TaskKind>();
+    const document = await collection.findOneAndUpdate({ _id: new ObjectId(taskId) }, update, {
       returnDocument: 'after',
     });
+
     if (!document) {
       throw new Error(`Task with ID ${taskId} not found`);
     }
     return document;
   }
 
-  private collection<TaskKind extends keyof TaskMapping>(): Collection<TaskDocument<TaskKind, TaskMapping[TaskKind]>> {
-    return this.database.collection<TaskDocument<TaskKind, TaskMapping[TaskKind]>>(this.config.collectionName);
+  private async collection<TaskKind extends keyof TaskMapping>(): Promise<
+    Collection<TaskDocument<TaskKind, TaskMapping[TaskKind]>>
+  > {
+    const database = await this.getDatabase();
+    return database.collection<TaskDocument<TaskKind, TaskMapping[TaskKind]>>(this.config.collectionName);
   }
 
   private toObject<TaskKind extends keyof TaskMapping>(

--- a/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
+++ b/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
@@ -41,6 +41,13 @@ describe('ChronoMongoDatastore', () => {
     await mongoClient.close();
   });
 
+  describe('setDatabase', () => {
+    test('should throw an error if the database connection is already set', async () => {
+      await expect(() => dataStore.setDatabase(mongoClient.db(DB_NAME))).rejects.toThrow(
+        'Database connection already set',
+      );
+    });
+  });
   describe('schedule', () => {
     describe('when called with valid input', () => {
       const input = {

--- a/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
+++ b/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
@@ -26,9 +26,11 @@ describe('ChronoMongoDatastore', () => {
 
     collection = mongoClient.db(DB_NAME).collection(TEST_DB_COLLECTION_NAME);
 
-    dataStore = await ChronoMongoDatastore.create(mongoClient.db(DB_NAME), {
+    dataStore = new ChronoMongoDatastore({
       collectionName: TEST_DB_COLLECTION_NAME,
     });
+
+    await dataStore.setDatabase(mongoClient.db(DB_NAME));
   });
 
   beforeEach(async () => {

--- a/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
+++ b/packages/chrono-mongo-datastore/test/unit/chrono-mongo-datastore.test.ts
@@ -30,7 +30,7 @@ describe('ChronoMongoDatastore', () => {
       collectionName: TEST_DB_COLLECTION_NAME,
     });
 
-    await dataStore.setDatabase(mongoClient.db(DB_NAME));
+    await dataStore.initialize(mongoClient.db(DB_NAME));
   });
 
   beforeEach(async () => {
@@ -41,22 +41,43 @@ describe('ChronoMongoDatastore', () => {
     await mongoClient.close();
   });
 
-  describe('setDatabase', () => {
+  describe('initialize', () => {
     test('should throw an error if the database connection is already set', async () => {
-      await expect(() => dataStore.setDatabase(mongoClient.db(DB_NAME))).rejects.toThrow(
+      await expect(() => dataStore.initialize(mongoClient.db(DB_NAME))).rejects.toThrow(
         'Database connection already set',
       );
     });
   });
-  describe('schedule', () => {
-    describe('when called with valid input', () => {
-      const input = {
-        kind: 'test' as const,
-        data: { test: 'test' },
-        priority: 1,
-        when: new Date(),
-      };
 
+  describe('schedule', () => {
+    const input = {
+      kind: 'test' as const,
+      data: { test: 'test' },
+      priority: 1,
+      when: new Date(),
+    };
+
+    describe('when called before initialize', () => {
+      test('should allow scheduling a task', async () => {
+        const store = new ChronoMongoDatastore({
+          collectionName: TEST_DB_COLLECTION_NAME,
+        });
+
+        const resultPromise = store.schedule(input);
+
+        await store.initialize(mongoClient.db(DB_NAME));
+
+        await expect(resultPromise).resolves.toEqual(
+          expect.objectContaining({
+            kind: input.kind,
+            status: 'PENDING',
+            data: input.data,
+          }),
+        );
+      });
+    });
+
+    describe('when called with valid input', () => {
       test('should return task with correct properties', async () => {
         const task = await dataStore.schedule(input);
 
@@ -121,6 +142,21 @@ describe('ChronoMongoDatastore', () => {
       priority: 1,
       when: new Date(Date.now() - 1),
     };
+
+    test('should allow claiming a task before initialize', async () => {
+      const store = new ChronoMongoDatastore({
+        collectionName: TEST_DB_COLLECTION_NAME,
+      });
+
+      const resultPromise = store.claim({
+        kind: input.kind,
+        claimStaleTimeoutMs: TEST_CLAIM_STALE_TIMEOUT_MS,
+      });
+
+      await store.initialize(mongoClient.db(DB_NAME));
+
+      await expect(resultPromise).resolves.toBeUndefined();
+    });
 
     test('should claim task in PENDING state with scheduledAt in the past', async () => {
       const task = await dataStore.schedule({
@@ -218,6 +254,31 @@ describe('ChronoMongoDatastore', () => {
   });
 
   describe('complete', () => {
+    test('should allow completing a task before initialize', async () => {
+      const task = await dataStore.schedule({
+        kind: 'test',
+        data: { test: 'test' },
+        priority: 1,
+        when: new Date(),
+      });
+
+      const store = new ChronoMongoDatastore({
+        collectionName: TEST_DB_COLLECTION_NAME,
+      });
+
+      const resultPromise = store.complete(task.id);
+
+      await store.initialize(mongoClient.db(DB_NAME));
+
+      await expect(resultPromise).resolves.toEqual(
+        expect.objectContaining({
+          id: task.id,
+          kind: task.kind,
+          status: TaskStatus.COMPLETED,
+        }),
+      );
+    });
+
     test('should mark task as completed', async () => {
       const task = await dataStore.schedule({
         kind: 'test',
@@ -256,6 +317,31 @@ describe('ChronoMongoDatastore', () => {
   });
 
   describe('fail', () => {
+    test('should allow failing a task before initialize', async () => {
+      const task = await dataStore.schedule({
+        kind: 'test',
+        data: { test: 'test' },
+        priority: 1,
+        when: new Date(),
+      });
+
+      const store = new ChronoMongoDatastore({
+        collectionName: TEST_DB_COLLECTION_NAME,
+      });
+
+      const resultPromise = store.fail(task.id);
+
+      await store.initialize(mongoClient.db(DB_NAME));
+
+      await expect(resultPromise).resolves.toEqual(
+        expect.objectContaining({
+          id: task.id,
+          kind: task.kind,
+          status: TaskStatus.FAILED,
+        }),
+      );
+    });
+
     test('should mark task as failed', async () => {
       const task = await dataStore.schedule({
         kind: 'test',
@@ -292,6 +378,31 @@ describe('ChronoMongoDatastore', () => {
   });
 
   describe('retryAt', () => {
+    test('should allow retrying a task before initialize', async () => {
+      const task = await dataStore.schedule({
+        kind: 'test',
+        data: { test: 'test' },
+        priority: 1,
+        when: new Date(),
+      });
+
+      const store = new ChronoMongoDatastore({
+        collectionName: TEST_DB_COLLECTION_NAME,
+      });
+
+      const resultPromise = store.retry(task.id, new Date());
+
+      await store.initialize(mongoClient.db(DB_NAME));
+
+      await expect(resultPromise).resolves.toEqual(
+        expect.objectContaining({
+          id: task.id,
+          kind: task.kind,
+          status: TaskStatus.PENDING,
+        }),
+      );
+    });
+
     test('should retry task', async () => {
       const firstScheduleDate = faker.date.past();
       const secondScheduleDate = faker.date.past();
@@ -340,6 +451,25 @@ describe('ChronoMongoDatastore', () => {
   });
 
   describe('delete', () => {
+    test('should allow deleting a task before initialize', async () => {
+      const task = await dataStore.schedule({
+        kind: 'test',
+        data: { test: 'test' },
+        priority: 1,
+        when: new Date(),
+      });
+
+      const store = new ChronoMongoDatastore({
+        collectionName: TEST_DB_COLLECTION_NAME,
+      });
+
+      const resultPromise = store.delete(task.id);
+
+      await store.initialize(mongoClient.db(DB_NAME));
+
+      await expect(resultPromise).resolves.toBeDefined();
+    });
+
     test('deletes task by id removing from datastore', async () => {
       const when = new Date();
 


### PR DESCRIPTION
## Description
- First implementation of allowing Chrono and Datastore to be created w/out actual DB connection with enque'd datastore operations while waiting for actual DB connection.