### PR TITLE
Updated event emitter import to be from node:events

### DIFF
--- a/packages/chrono-core/package.json
+++ b/packages/chrono-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neofinancial/chrono",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Core package for Chrono task scheduling system",
   "private": false,
   "publishConfig": {

--- a/packages/chrono-core/src/chrono.ts
+++ b/packages/chrono-core/src/chrono.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'node:stream';
+import { EventEmitter } from 'node:events';
 
 import type { BackoffStrategyOptions } from './backoff-strategy';
 import type { Datastore, ScheduleInput, Task } from './datastore';
@@ -17,29 +17,30 @@ export type ScheduleTaskInput<TaskKind, TaskData, DatastoreOptions> = ScheduleIn
 >;
 
 export type RegisterTaskHandlerInput<TaskKind, TaskData> = {
+  /** The type of task */
   kind: TaskKind;
+  /** The handler function to process the task */
   handler: (task: Task<TaskKind, TaskData>) => Promise<void>;
+  /** The options for the backoff strategy to use when the task handler fails */
   backoffStrategyOptions?: BackoffStrategyOptions;
+  /** The configuration for the processor to use when processing the task */
   processorConfiguration?: ProcessorConfiguration;
 };
 
+/**
+ * Response from registering a task handler.
+ * @returns The processor instance that can be used to start and stop the processor.
+ */
 export type RegisterTaskHandlerResponse<
   TaskKind extends keyof TaskMapping,
   TaskMapping extends TaskMappingBase,
 > = EventEmitter<ProcessorEventsMap<TaskKind, TaskMapping>>;
 
 /**
- * This is a type that represents the mapping of task kinds to their respective data types.
- *
- * Eg. shape of the TaskMapping type:
- *
- * type TaskMapping = {
- *   "async-messaging": { someField: number };
- *   "send-email": { url: string };
- * };
- *
+ * The main class for scheduling and processing tasks.
+ * @param datastore - The datastore instance to use for storing and retrieving tasks.
+ * @returns The Chrono instance that can be used to start and stop the processors as well as receive chrono instance events.
  */
-
 export class Chrono<TaskMapping extends TaskMappingBase, DatastoreOptions> extends EventEmitter<ChronoEventsMap> {
   private readonly datastore: Datastore<TaskMapping, DatastoreOptions>;
   private readonly processors: Map<keyof TaskMapping, Processor<keyof TaskMapping, TaskMapping>> = new Map();

--- a/packages/chrono-core/src/datastore.ts
+++ b/packages/chrono-core/src/datastore.ts
@@ -36,11 +36,17 @@ export type Task<TaskKind, TaskData> = {
 };
 
 export type ScheduleInput<TaskKind, TaskData, DatastoreOptions> = {
+  /** The date and time when the task is scheduled to run */
   when: Date;
+  /** The type of task */
   kind: TaskKind;
+  /** The payload or data associated with the task */
   data: TaskData;
+  /** The priority level of the task (lower numbers can indicate higher priority) */
   priority?: number;
+  /** A key used for idempotency to prevent duplicate processing */
   idempotencyKey?: string;
+  /** Additional options for the datastore to use when scheduling the task in the datastore. Can include things like a session for database transactions. Unique per datastore implementation.*/
   datastoreOptions?: DatastoreOptions;
 };
 

--- a/packages/chrono-core/src/processors/processor.ts
+++ b/packages/chrono-core/src/processors/processor.ts
@@ -1,4 +1,4 @@
-import type { EventEmitter } from 'node:stream';
+import type { EventEmitter } from 'node:events';
 import type { TaskMappingBase } from '..';
 import type { ProcessorEventsMap } from './events';
 

--- a/packages/chrono-core/src/processors/simple-processor.ts
+++ b/packages/chrono-core/src/processors/simple-processor.ts
@@ -1,6 +1,5 @@
-import { EventEmitter } from 'node:stream';
+import { EventEmitter } from 'node:events';
 import { setTimeout } from 'node:timers/promises';
-
 import type { BackoffStrategy } from '../backoff-strategy';
 import type { TaskMappingBase } from '../chrono';
 import type { Datastore, Task } from '../datastore';
@@ -19,12 +18,19 @@ const DEFAULT_CONFIG: SimpleProcessorConfig = {
 };
 
 type SimpleProcessorConfig = {
+  /** The maximum number of concurrent tasks that the processor will use when processing. @default 1 */
   maxConcurrency: number;
+  /** The interval at which the processor will wait before next poll when the previous poll returned a task @default 50ms */
   claimIntervalMs: number;
+  /** The maximum time a task can be claimed for processing before it will be considered stale and claimed again @default 10000ms */
   claimStaleTimeoutMs: number;
+  /** The interval at which the processor will wait before next poll when no tasks are available for processing @default 5000ms */
   idleIntervalMs: number;
+  /** The maximum time a task handler can take to complete before it will be considered timed out @default 5000ms */
   taskHandlerTimeoutMs: number;
+  /** The maximum number of retries for a task handler, before task is marked as failed. @default 5 */
   taskHandlerMaxRetries: number;
+  /** The interval at which the processor will wait before next poll when an unexpected error occurs @default 20000ms */
   processLoopRetryIntervalMs: number;
 };
 

--- a/packages/chrono-mongo-datastore/package.json
+++ b/packages/chrono-mongo-datastore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neofinancial/chrono-mongo-datastore",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "MongoDB datastore implementation for Chrono task scheduling system",
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
So it got brought to my attention that we were importing and using the EventEmitter class from node:streams when we should have been using node:events

Now based on my searching this difference is relatively harmless however apparently the one exported from node:stream has some pre-attached event types we are not using ('end', 'close', etc). So updating to use node:events as we want it only to be our custom events being emitted

Also added some more ts-docs and updated some dependencies